### PR TITLE
Fix channel mapping in MCC reader

### DIFF
--- a/edge/scr/acquire.py
+++ b/edge/scr/acquire.py
@@ -14,11 +14,10 @@ def main():
     board = open_mcc128()
     ch_mask, block = start_scan(board, chans, fs, AnalogInputRange.BIP_10V, cfg.get("scan_block_size", 1000))
     sender = InfluxSender()
-    num_ch = len(chans)
     map_cal = {c["ch"]:(c["sensor"], c["unit"], c["calib"]["gain"], c["calib"]["offset"]) for c in cfg["channels"]}
 
     while True:
-        raw = read_block(board, ch_mask, block, num_ch)
+        raw = read_block(board, ch_mask, block, chans)
         now_ns = time_ns()
         # para cada canal, aplica calibración y envía cada muestra
         for ch in chans:

--- a/edge/scr/mcc_reader.py
+++ b/edge/scr/mcc_reader.py
@@ -18,14 +18,14 @@ def start_scan(board, channels, fs_hz, v_range=AnalogInputRange.BIP_10V, block_s
     )
     return ch_mask, block_samples
 
-def read_block(board, ch_mask, block_samples, num_ch):
+def read_block(board, ch_mask, block_samples, channels):
     data = board.a_in_scan_read(block_samples, 5.0)  # timeout 5s
     if data.hardware_overrun or data.buffer_overrun:
         raise RuntimeError("Overrun de hardware/buffer")
     # data.data -> lista intercalada por canal
     # reacomoda a dict canal->lista
-    out = {ch: [] for ch in range(8)}
+    out = {ch: [] for ch in channels}
     for i, val in enumerate(data.data):
-        ch = i % num_ch
-        out[ch].append(val)
+        channel = channels[i % len(channels)]
+        out[channel].append(val)
     return out


### PR DESCRIPTION
## Summary
- update the MCC reader to build output buffers using the configured channel IDs
- map interleaved samples back to the proper channel order during block reads
- adjust the acquisition loop to pass the channel list to the reader

## Testing
- python -m compileall edge/scr

------
https://chatgpt.com/codex/tasks/task_e_68cce58818dc83318a9de20dc89b1f8d