### PR TITLE
Handle queue overflow when requeueing lines

### DIFF
--- a/edge/scr/sender.py
+++ b/edge/scr/sender.py
@@ -1,5 +1,7 @@
-import time, queue, threading, requests, os
+import time, queue, threading, requests, os, logging
 from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
 
 class InfluxSender:
     def __init__(self):
@@ -30,19 +32,65 @@ class InfluxSender:
                     headers=headers, data=data, timeout=5
                 )
                 if r.status_code >= 300:
+                    logger.warning(
+                        "InfluxSender write failed with status %s; re-queueing %d lines.",
+                        r.status_code,
+                        len(lines),
+                    )
                     # re-enqueue si falla (simple)
-                    for ln in lines: self.q.put_nowait(ln)
+                    self._queue_lines(lines, context=f"HTTP {r.status_code} retry")
                     time.sleep(2)
-            except Exception:
-                for ln in lines: self.q.put_nowait(ln)
+            except Exception as exc:
+                logger.warning(
+                    "InfluxSender write raised %s; re-queueing %d lines.",
+                    exc,
+                    len(lines),
+                )
+                self._queue_lines(lines, context=f"exception {type(exc).__name__}")
                 time.sleep(2)
 
     def enqueue(self, line: str):
+        self._queue_lines([line], context="enqueue")
+
+    def _queue_lines(self, lines, context: str):
+        idx = 0
         try:
-            self.q.put_nowait(line)
+            for idx, ln in enumerate(lines):
+                self.q.put_nowait(ln)
         except queue.Full:
-            # último recurso: drop con marca
-            pass
+            self._handle_queue_full(lines[idx:], context)
+
+    def _handle_queue_full(self, pending_lines, context: str):
+        for ln in pending_lines:
+            self._put_with_overflow_policy(ln, context)
+
+    def _put_with_overflow_policy(self, line, context: str):
+        while True:
+            try:
+                self.q.put_nowait(line)
+                return
+            except queue.Full:
+                if not self._drop_oldest(context):
+                    logger.error(
+                        "InfluxSender unable to enqueue data during %s due to persistent congestion; dropping sample.",
+                        context,
+                    )
+                    return
+
+    def _drop_oldest(self, context: str) -> bool:
+        try:
+            self.q.get_nowait()
+        except queue.Empty:
+            logger.warning(
+                "InfluxSender detected queue overflow during %s but found queue empty; dropping pending data.",
+                context,
+            )
+            return False
+        logger.warning(
+            "InfluxSender queue full during %s; dropping oldest sample to relieve congestion.",
+            context,
+        )
+        return True
 
 def to_line(meas, tags: dict, fields: dict, ts_ns: int):
     t = ",".join(f"{k}={v}" for k,v in tags.items())


### PR DESCRIPTION
## Summary
- protect requeue loops against queue.Full exceptions to keep the worker thread alive
- introduce a drop-oldest policy and logging warnings when the queue overflows to surface congestion

## Testing
- python -m compileall edge/scr/sender.py

------
https://chatgpt.com/codex/tasks/task_e_68cce58864fc83318cf565008dbaf2e1