### PR TITLE
Add InfluxDB env template and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # raspi-mcc128-influx
 DAQ RBP5 with MCC128 to InfluxDB
+
+## Configuración de credenciales de InfluxDB
+
+1. Copie `edge/.env.example` a `edge/.env` y complete sus valores reales de InfluxDB.
+2. Verifique las credenciales antes de iniciar el servicio:
+   ```bash
+   curl --request GET "$INFLUX_URL/api/v2/buckets" \
+     --header "Authorization: Token $INFLUX_TOKEN" \
+     --header "Accept: application/json"
+   ```
+   La llamada debe devolver 200 OK si `INFLUX_URL` e `INFLUX_TOKEN` son correctos.
+3. Asegure los permisos del archivo con `chmod 600 edge/.env`.
+4. Recargue el servicio con `sudo systemctl restart edge.service` para que systemd lea las nuevas variables.

--- a/edge/.env.example
+++ b/edge/.env.example
@@ -1,0 +1,6 @@
+# Copie este archivo a .env y complete las credenciales reales de InfluxDB.
+# Asigne permisos 600 al archivo .env para proteger el token antes de iniciar el servicio.
+INFLUX_URL=http://localhost:8086
+INFLUX_ORG=example-org
+INFLUX_BUCKET=example-bucket
+INFLUX_TOKEN=example-token


### PR DESCRIPTION
## Summary
- add an edge/.env.example template listing the required InfluxDB variables
- document how to validate credentials, secure the .env file, and restart the edge.service unit

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccea796358833184317d021c8cd8d8