### PR TITLE
Load .env outside systemd and validate Influx env

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,19 @@ DAQ RBP5 with MCC128 to InfluxDB
    La llamada debe devolver 200 OK si `INFLUX_URL` e `INFLUX_TOKEN` son correctos.
 3. Asegure los permisos del archivo con `chmod 600 edge/.env`.
 4. Recargue el servicio con `sudo systemctl restart edge.service` para que systemd lea las nuevas variables.
+
+### Prueba manual del mensaje de error por credenciales faltantes
+
+El proceso `InfluxSender` valida que `INFLUX_URL`, `INFLUX_ORG`, `INFLUX_BUCKET` e `INFLUX_TOKEN` tengan contenido. Si falta alguna, lanza un `RuntimeError` con el texto `Faltan configuraciones obligatorias: ...`.
+
+Para probarlo durante el desarrollo (fuera de systemd) puede vaciar temporalmente una variable en `edge/.env` y ejecutar:
+
+```bash
+cd edge
+python - <<'PY'
+from scr.sender import InfluxSender
+InfluxSender()
+PY
+```
+
+La ejecución debe finalizar con la excepción mencionada, indicando el nombre de la variable faltante y cómo definirla.


### PR DESCRIPTION
## Summary
- load the edge/.env file automatically when the sender runs outside of systemd
- raise a RuntimeError when required InfluxDB environment variables are missing, including guidance on how to define them
- document a manual verification snippet for the new error handling message

## Testing
- python -m compileall edge/scr/sender.py

------
https://chatgpt.com/codex/tasks/task_e_68cced4016fc8331bc3b5a50cbfc8f5b