### PR TITLE
Ensure acquisition cleans up scan and sender thread

### DIFF
--- a/edge/scr/acquire.py
+++ b/edge/scr/acquire.py
@@ -11,33 +11,48 @@ def main():
     pi = cfg["station_id"]
     fs = cfg["sample_rate_hz"]
     chans = [c["ch"] for c in cfg["channels"]]
-    board = open_mcc128()
-    ch_mask, block = start_scan(board, chans, fs, AnalogInputRange.BIP_10V, cfg.get("scan_block_size", 1000))
-    sender = InfluxSender()
-    map_cal = {c["ch"]:(c["sensor"], c["unit"], c["calib"]["gain"], c["calib"]["offset"]) for c in cfg["channels"]}
+    board = None
+    sender = None
+    try:
+        board = open_mcc128()
+        ch_mask, block = start_scan(board, chans, fs, AnalogInputRange.BIP_10V, cfg.get("scan_block_size", 1000))
+        sender = InfluxSender()
+        map_cal = {c["ch"]:(c["sensor"], c["unit"], c["calib"]["gain"], c["calib"]["offset"]) for c in cfg["channels"]}
 
-    ts_step = int(1e9 / fs)
+        ts_step = int(1e9 / fs)
 
-    while True:
-        raw = read_block(board, ch_mask, block, chans)
-        now_ns = time_ns()
-        block_len = len(raw[chans[0]]) if chans else 0
-        if block_len == 0:
-            continue
-        ts0 = now_ns - ts_step * (block_len - 1)
-        # para cada canal, aplica calibración y envía cada muestra
-        for ch in chans:
-            sensor, unit, gain, offset = map_cal[ch]
-            vals = apply_calibration(raw[ch], gain, offset)
-            # empaqueta por muestra (si el volumen es alto, agrega por estadísticos por bloque)
-            for i, mm in enumerate(vals):
-                line = to_line(
-                    "lvdt",
-                    tags={"pi":pi, "canal":ch, "sensor":sensor, "unidad":unit},
-                    fields={"valor":float(mm)},
-                    ts_ns=ts0 + i*ts_step
-                )
-                sender.enqueue(line)
+        while True:
+            raw = read_block(board, ch_mask, block, chans)
+            now_ns = time_ns()
+            block_len = len(raw[chans[0]]) if chans else 0
+            if block_len == 0:
+                continue
+            ts0 = now_ns - ts_step * (block_len - 1)
+            # para cada canal, aplica calibración y envía cada muestra
+            for ch in chans:
+                sensor, unit, gain, offset = map_cal[ch]
+                vals = apply_calibration(raw[ch], gain, offset)
+                # empaqueta por muestra (si el volumen es alto, agrega por estadísticos por bloque)
+                for i, mm in enumerate(vals):
+                    line = to_line(
+                        "lvdt",
+                        tags={"pi":pi, "canal":ch, "sensor":sensor, "unidad":unit},
+                        fields={"valor":float(mm)},
+                        ts_ns=ts0 + i*ts_step
+                    )
+                    sender.enqueue(line)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if sender is not None:
+            sender.close()
+        if board is not None:
+            stop_scan = getattr(board, "a_in_scan_stop", None)
+            if callable(stop_scan):
+                stop_scan()
+            cleanup_scan = getattr(board, "a_in_scan_cleanup", None)
+            if callable(cleanup_scan):
+                cleanup_scan()
 
 if __name__ == "__main__":
     main()

--- a/edge/scr/sender.py
+++ b/edge/scr/sender.py
@@ -52,6 +52,12 @@ class InfluxSender:
     def enqueue(self, line: str):
         self._queue_lines([line], context="enqueue")
 
+    def close(self):
+        if self.stop:
+            return
+        self.stop = True
+        self.t.join()
+
     def _queue_lines(self, lines, context: str):
         idx = 0
         try:


### PR DESCRIPTION
## Summary
- wrap the acquisition loop in a try/finally block that stops and cleans up the MCC128 scan and closes the Influx sender
- add an explicit close method to InfluxSender so its worker thread terminates cleanly

## Testing
- python -m compileall edge/scr

------
https://chatgpt.com/codex/tasks/task_e_68cced4eded08331ba1ca7a83aeb8e8a