### PR TITLE
Add dynamic timeout calculation for MCC128 reads

### DIFF
--- a/edge/config/sensors.yaml
+++ b/edge/config/sensors.yaml
@@ -1,6 +1,6 @@
 station_id: rpi5-a
 sample_rate_hz: 10
-scan_block_size: 50         # bloques de 5 s para respetar timeout de read_block
+scan_block_size: 50         # bloque de 5 s -> timeout dinámico = 5 s + 0.5 s de margen
 channels:
   - ch: 0
     sensor: LVDT_P1

--- a/edge/scr/acquire.py
+++ b/edge/scr/acquire.py
@@ -2,7 +2,7 @@ import os, time
 import yaml
 from time import time_ns
 from daqhats import AnalogInputRange
-from mcc_reader import open_mcc128, start_scan, read_block
+from mcc_reader import open_mcc128, start_scan, read_block, DEFAULT_TIMEOUT_MARGIN_S
 from calibrate import apply_calibration
 from sender import InfluxSender, to_line
 
@@ -18,8 +18,11 @@ def main():
 
     ts_step = int(1e9 / fs)
 
+    block_duration_s = block / float(fs) if fs else 0.0
+    timeout_s = block_duration_s + DEFAULT_TIMEOUT_MARGIN_S
+
     while True:
-        raw = read_block(board, ch_mask, block, chans)
+        raw = read_block(board, ch_mask, block, chans, timeout=timeout_s)
         now_ns = time_ns()
         block_len = len(raw[chans[0]]) if chans else 0
         if block_len == 0:


### PR DESCRIPTION
## Summary
- allow read_block to accept a caller-provided timeout or compute one based on sampling settings
- compute the scan read timeout from the block size and sample rate in the acquisition loop and document the new margin in the config

## Testing
- python -m compileall edge/scr

------
https://chatgpt.com/codex/tasks/task_e_68cced64f23c8331b04da042ef7c1ef4