### PR TITLE
Ensure read_block receives sample rate

### DIFF
--- a/edge/scr/acquire.py
+++ b/edge/scr/acquire.py
@@ -22,7 +22,7 @@ def main():
         ts_step = int(1e9 / fs)
 
         while True:
-            raw = read_block(board, ch_mask, block, chans)
+            raw = read_block(board, ch_mask, block, chans, sample_rate_hz=fs)
             now_ns = time_ns()
             block_len = len(raw[chans[0]]) if chans else 0
             if block_len == 0:


### PR DESCRIPTION
## Summary
- pass the configured sampling rate when calling read_block so its dynamic timeout can be computed

## Testing
- python -m compileall edge/scr

------
https://chatgpt.com/codex/tasks/task_e_68ccf4c0f3d48331b770b4150b4a00d0