### PR TITLE
Pass sample rate to read_block

### DIFF
--- a/edge/scr/acquire.py
+++ b/edge/scr/acquire.py
@@ -22,7 +22,7 @@ def main():
         ts_step = int(1e9 / fs)
 
         while True:
-            raw = read_block(board, ch_mask, block, chans)
+            raw = read_block(board, ch_mask, block, chans, sample_rate_hz=fs)
             now_ns = time_ns()
             block_len = len(raw[chans[0]]) if chans else 0
             if block_len == 0:


### PR DESCRIPTION
## Summary
- ensure acquire passes the configured sample rate to mcc_reader.read_block so the dynamic timeout logic can compute correctly

## Testing
- python -m compileall edge/scr

------
https://chatgpt.com/codex/tasks/task_e_68ccf5180c0c8331bdcf218f929f0885