### PR TITLE
Add calibration tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run tests
+        run: pytest

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,0 +1,48 @@
+import math
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Allow importing scripts from the edge/scr directory.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "edge" / "scr"))
+
+from calibrate import apply_calibration  # type: ignore  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "voltages, gain, offset, expected",
+    [
+        ([0.0, 0.5, 1.0], 2.0, 0.0, [0.0, 1.0, 2.0]),
+        ([-1.0, 0.0, 1.0], 1.5, -0.2, [-1.7, -0.2, 1.3]),
+        ([-0.5, 0.5], -1.0, 0.1, [0.6, -0.4]),
+    ],
+)
+def test_apply_calibration_varied_inputs(voltages, gain, offset, expected):
+    """apply_calibration should handle positive/negative values and offsets."""
+
+    calibrated = apply_calibration(voltages, gain, offset)
+
+    assert calibrated == pytest.approx(expected)
+
+
+def test_sensor_calibration_entries_are_numeric():
+    """Each configured channel must define numeric gain and offset values."""
+
+    config_path = Path(__file__).resolve().parents[1] / "edge" / "config" / "sensors.yaml"
+    with config_path.open("r", encoding="utf-8") as f:
+        sensors_config = yaml.safe_load(f)
+
+    channels = sensors_config.get("channels", [])
+    assert channels, "No channels defined in sensors configuration"
+
+    for channel in channels:
+        calib = channel.get("calib")
+        assert isinstance(calib, dict), f"Channel {channel} missing calibration info"
+
+        for key in ("gain", "offset"):
+            assert key in calib, f"Calibration entry missing '{key}'"
+            value = calib[key]
+            assert isinstance(value, (int, float)), f"{key} is not numeric: {value!r}"
+            assert not math.isnan(value), f"{key} must not be NaN"


### PR DESCRIPTION
## Summary
- add pytest coverage for apply_calibration and validate calibration data from sensors.yaml
- configure a GitHub Actions workflow to run the test suite on every push and pull request

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccf54d52148331b8061e4f033d03bf