### PR TITLE
Handle MCC128 read errors with retry and reconnection

### DIFF
--- a/edge/scr/acquire.py
+++ b/edge/scr/acquire.py
@@ -1,10 +1,25 @@
-import os, time
+import time
+import logging
 import yaml
 from time import time_ns
 from daqhats import AnalogInputRange
-from mcc_reader import open_mcc128, start_scan, read_block, DEFAULT_TIMEOUT_MARGIN_S
+from mcc_reader import open_mcc128, start_scan, read_block
 from calibrate import apply_calibration
 from sender import InfluxSender, to_line
+
+
+logger = logging.getLogger(__name__)
+
+
+def _stop_and_cleanup(board):
+    if board is None:
+        return
+    stop_scan = getattr(board, "a_in_scan_stop", None)
+    if callable(stop_scan):
+        stop_scan()
+    cleanup_scan = getattr(board, "a_in_scan_cleanup", None)
+    if callable(cleanup_scan):
+        cleanup_scan()
 
 def main():
     cfg = yaml.safe_load(open("config/sensors.yaml","r"))
@@ -15,14 +30,41 @@ def main():
     sender = None
     try:
         board = open_mcc128()
-        ch_mask, block = start_scan(board, chans, fs, AnalogInputRange.BIP_10V, cfg.get("scan_block_size", 1000))
+        block = cfg.get("scan_block_size", 1000)
+        ch_mask, block = start_scan(board, chans, fs, AnalogInputRange.BIP_10V, block)
         sender = InfluxSender()
         map_cal = {c["ch"]:(c["sensor"], c["unit"], c["calib"]["gain"], c["calib"]["offset"]) for c in cfg["channels"]}
 
         ts_step = int(1e9 / fs)
+        retry_backoff_s = cfg.get("scan_retry_backoff_s", 5)
+        max_retries = cfg.get("scan_max_retries", 3)
+        retry_count = 0
 
         while True:
-            raw = read_block(board, ch_mask, block, chans, sample_rate_hz=fs)
+            try:
+                raw = read_block(board, ch_mask, block, chans, sample_rate_hz=fs)
+                retry_count = 0
+            except RuntimeError as exc:
+                retry_count += 1
+                logger.warning(
+                    "Fallo en read_block (intento %s/%s): %s",
+                    retry_count,
+                    max_retries,
+                    exc,
+                )
+                _stop_and_cleanup(board)
+                time.sleep(retry_backoff_s)
+                if retry_count > max_retries:
+                    logger.error(
+                        "Se superó el máximo de reintentos (%s); reabriendo MCC128.",
+                        max_retries,
+                    )
+                    close_board = getattr(board, "close", None)
+                    if callable(close_board):
+                        close_board()
+                    board = open_mcc128()
+                ch_mask, block = start_scan(board, chans, fs, AnalogInputRange.BIP_10V, block)
+                continue
             now_ns = time_ns()
             block_len = len(raw[chans[0]]) if chans else 0
             if block_len == 0:
@@ -47,12 +89,7 @@ def main():
         if sender is not None:
             sender.close()
         if board is not None:
-            stop_scan = getattr(board, "a_in_scan_stop", None)
-            if callable(stop_scan):
-                stop_scan()
-            cleanup_scan = getattr(board, "a_in_scan_cleanup", None)
-            if callable(cleanup_scan):
-                cleanup_scan()
+            _stop_and_cleanup(board)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_acquire.py
+++ b/tests/test_acquire.py
@@ -1,0 +1,125 @@
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+# Allow importing scripts from the edge/scr directory.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "edge" / "scr"))
+
+
+import acquire  # type: ignore  # noqa: E402
+
+
+class DummyBoard:
+    def __init__(self, name: str):
+        self.name = name
+        self.stop_calls = 0
+        self.cleanup_calls = 0
+        self.closed = False
+
+    def a_in_scan_stop(self):
+        self.stop_calls += 1
+
+    def a_in_scan_cleanup(self):
+        self.cleanup_calls += 1
+
+    def close(self):
+        self.closed = True
+
+
+class DummySender:
+    def __init__(self):
+        self.lines = []
+        self.closed = False
+
+    def enqueue(self, line: str):  # pragma: no cover - simple collector
+        self.lines.append(line)
+
+    def close(self):
+        self.closed = True
+
+
+def test_acquire_reconnects_after_read_errors(monkeypatch, caplog):
+    boards = []
+    start_calls = []
+    sleep_calls = []
+    senders = []
+
+    def fake_open_mcc128():
+        board = DummyBoard(f"board{len(boards) + 1}")
+        boards.append(board)
+        return board
+
+    def fake_start_scan(board, channels, fs, v_range, block_size):
+        start_calls.append((board.name, block_size))
+        return 0x1, block_size
+
+    actions = iter(["runtime", "runtime", "runtime", "success", "runtime", "keyboard"])
+
+    def fake_read_block(board, ch_mask, block, channels, sample_rate_hz=None):
+        action = next(actions)
+        if action == "runtime":
+            raise RuntimeError("boom")
+        if action == "success":
+            return {channels[0]: [1.23]}
+        raise KeyboardInterrupt
+
+    def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    config = {
+        "station_id": "pi-test",
+        "sample_rate_hz": 10,
+        "scan_block_size": 2,
+        "scan_retry_backoff_s": 0,
+        "scan_max_retries": 2,
+        "channels": [
+            {
+                "ch": 0,
+                "sensor": "sensor-0",
+                "unit": "u",
+                "calib": {"gain": 1.0, "offset": 0.0},
+            }
+        ],
+    }
+
+    monkeypatch.setattr(acquire, "open_mcc128", fake_open_mcc128)
+    monkeypatch.setattr(acquire, "start_scan", fake_start_scan)
+    monkeypatch.setattr(acquire, "read_block", fake_read_block)
+    monkeypatch.setattr(acquire.yaml, "safe_load", lambda _: config)
+    monkeypatch.setattr(acquire, "InfluxSender", lambda: senders.append(DummySender()) or senders[-1])
+    monkeypatch.setattr(acquire, "time_ns", lambda: 1_500_000_000)
+    monkeypatch.setattr(acquire.time, "sleep", fake_sleep)
+    monkeypatch.setattr(acquire, "AnalogInputRange", SimpleNamespace(BIP_10V=object()))
+    monkeypatch.chdir(Path(__file__).resolve().parents[1] / "edge")
+
+    caplog.set_level(logging.WARNING, logger=acquire.logger.name)
+
+    acquire.main()
+
+    assert len(boards) == 2
+    assert boards[0].stop_calls == boards[0].cleanup_calls == 3
+    assert boards[0].closed is True
+    assert boards[1].stop_calls == boards[1].cleanup_calls == 2
+
+    assert sleep_calls == [0, 0, 0, 0]
+    assert start_calls == [
+        ("board1", 2),
+        ("board1", 2),
+        ("board1", 2),
+        ("board2", 2),
+        ("board2", 2),
+    ]
+
+    assert senders and senders[0].closed is True
+    assert len(senders[0].lines) == 1
+
+    warning_messages = [rec.getMessage() for rec in caplog.records if rec.levelno == logging.WARNING]
+    assert warning_messages[0].startswith("Fallo en read_block (intento 1/2)")
+    assert warning_messages[1].startswith("Fallo en read_block (intento 2/2)")
+    assert warning_messages[2].startswith("Fallo en read_block (intento 3/2)")
+    assert warning_messages[3].startswith("Fallo en read_block (intento 1/2)")
+
+    error_messages = [rec.getMessage() for rec in caplog.records if rec.levelno == logging.ERROR]
+    assert any("reabriendo MCC128" in msg for msg in error_messages)


### PR DESCRIPTION
## Summary
- wrap the acquisition loop in a retry handler that logs MCC128 read errors, backs off, and restarts scans
- reopen the MCC128 device after exceeding the configured retry limit and reset the counter after successful reads
- add a pytest that mocks the acquisition stack to validate the reconnection flow and logging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccf98aed1083319a90c1d433cae372