### PR TITLE
Improve Influx sender resilience and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ pip install -r requirements.txt
    ```
    Debe responder `200 OK`. Un `401` indica token/organización incorrectos.
 
+3. Opcionalmente puede ajustar el comportamiento del envío agregando variables como `INFLUX_BATCH_SIZE`, `INFLUX_RETRY_MAX_ATTEMPTS`, `INFLUX_RETRY_BASE_DELAY_S` e `INFLUX_RETRY_MAX_BACKOFF_S` para controlar el tamaño del lote y la estrategia de reintentos (ver `.env.example`).
+
 ### Sensores y adquisición (`edge/config/sensors.yaml`)
 Ajuste los canales, nombres, unidades y calibraciones según su montaje. Ejemplo incluido:
 ```yaml

--- a/edge/.env.example
+++ b/edge/.env.example
@@ -4,3 +4,9 @@ INFLUX_URL=http://localhost:8086
 INFLUX_ORG=example-org
 INFLUX_BUCKET=example-bucket
 INFLUX_TOKEN=example-token
+# Opcionales: ajuste rendimiento/reintentos según su entorno
+#INFLUX_BATCH_SIZE=5
+#INFLUX_RETRY_MAX_ATTEMPTS=5
+#INFLUX_RETRY_BASE_DELAY_S=1.0
+#INFLUX_RETRY_MAX_BACKOFF_S=30.0
+#INFLUX_TIMEOUT_S=5.0

--- a/edge/scr/sender.py
+++ b/edge/scr/sender.py
@@ -1,6 +1,13 @@
-import time, queue, threading, requests, os, logging
-from datetime import datetime, timezone
+import logging
+import os
+import queue
+import random
+import threading
+import time
 from pathlib import Path
+from typing import Iterable, List, Optional
+
+import requests
 
 
 logger = logging.getLogger(__name__)
@@ -25,12 +32,20 @@ def _load_dotenv_if_needed():
 
 _load_dotenv_if_needed()
 
+RETRIABLE_4XX = {408, 409, 425, 429}
+
+
 class InfluxSender:
-    def __init__(self):
+    def __init__(self, *, session: Optional[requests.Session] = None, start_worker: bool = True):
         self.url = os.getenv("INFLUX_URL")  # ej. http://WINDOWS_IP:8086
         self.org = os.getenv("INFLUX_ORG")
         self.bucket = os.getenv("INFLUX_BUCKET")
         self.token = os.getenv("INFLUX_TOKEN")
+        self.batch_size = self._read_int_env("INFLUX_BATCH_SIZE", default=5, minimum=1)
+        self.max_attempts = self._read_int_env("INFLUX_RETRY_MAX_ATTEMPTS", default=5, minimum=1)
+        self.base_backoff = self._read_float_env("INFLUX_RETRY_BASE_DELAY_S", default=1.0, minimum=0.0)
+        self.max_backoff = self._read_float_env("INFLUX_RETRY_MAX_BACKOFF_S", default=30.0, minimum=0.0)
+        self.timeout = self._read_float_env("INFLUX_TIMEOUT_S", default=5.0, minimum=0.1)
         missing = [
             name
             for name, value in (
@@ -54,43 +69,139 @@ class InfluxSender:
             )
         self.q = queue.Queue(maxsize=1000)
         self.stop = False
-        self.t = threading.Thread(target=self._worker, daemon=True)
-        self.t.start()
+        self.session = session or requests.Session()
+        self._sleep = time.sleep
+        self._worker_thread: Optional[threading.Thread] = None
+        if start_worker:
+            self._worker_thread = threading.Thread(target=self._worker, daemon=True)
+            self._worker_thread.start()
+
+    @staticmethod
+    def _read_int_env(name: str, default: int, minimum: int) -> int:
+        try:
+            value = int(os.getenv(name, default))
+        except ValueError:
+            logger.warning("Valor inválido para %s; usando %s", name, default)
+            value = default
+        return max(value, minimum)
+
+    @staticmethod
+    def _read_float_env(name: str, default: float, minimum: float) -> float:
+        try:
+            value = float(os.getenv(name, default))
+        except ValueError:
+            logger.warning("Valor inválido para %s; usando %s", name, default)
+            value = default
+        return max(value, minimum)
 
     def _worker(self):
         while not self.stop:
-            lines = []
-            try:
-                # junta hasta 5 bloques para eficiencia
-                for _ in range(5):
-                    lines.append(self.q.get(timeout=1))
-            except queue.Empty:
-                pass
-            if not lines: continue
-            data = "\n".join(lines)
-            headers = {"Authorization": f"Token {self.token}"}
-            try:
-                r = requests.post(
-                    f"{self.url}/api/v2/write?org={self.org}&bucket={self.bucket}&precision=ns",
-                    headers=headers, data=data, timeout=5
-                )
-                if r.status_code >= 300:
-                    logger.warning(
-                        "InfluxSender write failed with status %s; re-queueing %d lines.",
-                        r.status_code,
-                        len(lines),
-                    )
-                    # re-enqueue si falla (simple)
-                    self._queue_lines(lines, context=f"HTTP {r.status_code} retry")
-                    time.sleep(2)
-            except Exception as exc:
-                logger.warning(
-                    "InfluxSender write raised %s; re-queueing %d lines.",
-                    exc,
+            lines = self._drain_batch()
+            if not lines:
+                continue
+            success = self._send_with_retries(lines)
+            if not success:
+                logger.error(
+                    "InfluxSender dropping %d lines after exhausting retries.",
                     len(lines),
                 )
-                self._queue_lines(lines, context=f"exception {type(exc).__name__}")
-                time.sleep(2)
+
+    def _drain_batch(self) -> List[str]:
+        lines: List[str] = []
+        try:
+            line = self.q.get(timeout=1)
+        except queue.Empty:
+            return lines
+
+        lines.append(line)
+        while len(lines) < self.batch_size:
+            try:
+                lines.append(self.q.get_nowait())
+            except queue.Empty:
+                break
+        return lines
+
+    def _send_with_retries(self, lines: Iterable[str]) -> bool:
+        data = "\n".join(lines)
+        headers = {"Authorization": f"Token {self.token}"}
+        url = f"{self.url}/api/v2/write?org={self.org}&bucket={self.bucket}&precision=ns"
+        for attempt in range(1, self.max_attempts + 1):
+            try:
+                response = self.session.post(url, headers=headers, data=data, timeout=self.timeout)
+            except requests.RequestException as exc:
+                reason = f"{type(exc).__name__}: {exc}"
+                if attempt == self.max_attempts:
+                    logger.error(
+                        "InfluxSender write failed after %d/%d attempts (%s).", attempt, self.max_attempts, reason
+                    )
+                    return False
+                delay = self._compute_backoff(attempt)
+                logger.warning(
+                    "InfluxSender write attempt %d/%d raised %s; retrying in %.2fs.",
+                    attempt,
+                    self.max_attempts,
+                    reason,
+                    delay,
+                )
+                self._sleep(delay)
+                continue
+
+            if response.status_code < 300:
+                if attempt > 1:
+                    logger.info("InfluxSender write succeeded after %d attempts.", attempt)
+                return True
+
+            reason = f"HTTP {response.status_code}"
+            body = self._extract_body(response)
+            headers_payload = dict(response.headers)
+            should_retry = self._should_retry(response.status_code)
+            log_message = (
+                "InfluxSender write attempt %d/%d failed (%s). status=%s headers=%s body=%s"
+            )
+            payload = (
+                attempt,
+                self.max_attempts,
+                reason,
+                response.status_code,
+                headers_payload,
+                body,
+            )
+
+            if not should_retry or attempt == self.max_attempts:
+                logger.error(log_message, *payload)
+                return False
+
+            delay = self._compute_backoff(attempt)
+            logger.warning(log_message + "; retrying in %.2fs.", *payload, delay)
+            self._sleep(delay)
+
+        return False
+
+    def _should_retry(self, status_code: int) -> bool:
+        if status_code >= 500:
+            return True
+        if 400 <= status_code < 500:
+            return status_code in RETRIABLE_4XX
+        return False
+
+    def _compute_backoff(self, attempt: int) -> float:
+        exp_delay = self.base_backoff * (2 ** (attempt - 1))
+        exp_delay = min(exp_delay, self.max_backoff) if self.max_backoff else exp_delay
+        jitter = random.uniform(0, self.base_backoff) if self.base_backoff else 0.0
+        total = exp_delay + jitter
+        if self.max_backoff:
+            total = min(total, self.max_backoff)
+        return total
+
+    @staticmethod
+    def _extract_body(response: requests.Response, limit: int = 512) -> str:
+        try:
+            body = response.text or ""
+        except Exception as exc:  # pragma: no cover - extremely rare
+            return f"<unable to decode body: {exc}>"
+        if len(body) <= limit:
+            return body
+        return f"{body[:limit]}... [truncated {len(body) - limit} chars]"
 
     def enqueue(self, line: str):
         self._queue_lines([line], context="enqueue")
@@ -99,7 +210,9 @@ class InfluxSender:
         if self.stop:
             return
         self.stop = True
-        self.t.join()
+        if self._worker_thread:
+            self._worker_thread.join()
+        self.session.close()
 
     def _queue_lines(self, lines, context: str):
         idx = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ daqhats
 requests
 python-dotenv
 pyyaml
+responses

--- a/responses.py
+++ b/responses.py
@@ -1,0 +1,134 @@
+"""Minimal stub of the ``responses`` library for offline testing."""
+
+from __future__ import annotations
+
+import functools
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+from unittest import mock
+
+import requests
+
+
+GET = "GET"
+POST = "POST"
+PUT = "PUT"
+DELETE = "DELETE"
+
+
+@dataclass
+class _RegisteredCall:
+    method: str
+    url: str
+    status: int
+    headers: Dict[str, str]
+    body: Any
+
+
+@dataclass
+class _CallRecord:
+    request: requests.PreparedRequest
+    response: requests.Response
+
+
+class _ResponsesMock:
+    def __init__(self) -> None:
+        self.calls: List[_CallRecord] = []
+        self._registry: List[_RegisteredCall] = []
+        self._patcher: Optional[mock._patch] = None
+
+    def __enter__(self) -> "_ResponsesMock":
+        self._patcher = mock.patch("requests.sessions.Session.request", side_effect=self._dispatch)
+        self._patcher.start()
+        self.calls.clear()
+        self._registry.clear()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._patcher is not None:
+            self._patcher.stop()
+            self._patcher = None
+        self.calls.clear()
+        self._registry.clear()
+
+    def add(self, method: str, url: str, *, status: int = 200, headers: Optional[Dict[str, str]] = None, body: Any = "") -> None:
+        self._registry.append(_RegisteredCall(method.upper(), url, status, headers or {}, body))
+
+    def _dispatch(self, method: str, url: str, **kwargs) -> requests.Response:
+        if not self._registry:
+            raise AssertionError(f"No mocked response available for {method} {url}")
+        registered = self._registry.pop(0)
+        if registered.method != method.upper() or registered.url != url:
+            raise AssertionError(
+                f"Unexpected request {method.upper()} {url}; next registered is {registered.method} {registered.url}"
+            )
+
+        response = requests.Response()
+        response.status_code = registered.status
+        response.headers = registered.headers
+        if isinstance(registered.body, bytes):
+            content = registered.body
+        else:
+            content = str(registered.body).encode("utf-8")
+        response._content = content
+        response.url = url
+        request = requests.Request(method=method.upper(), url=url).prepare()
+        response.request = request
+        self.calls.append(_CallRecord(request=request, response=response))
+        return response
+
+
+class _CallsProxy:
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(_get_active_mock().calls)
+
+    def __iter__(self):  # pragma: no cover - not used but keeps parity
+        return iter(_get_active_mock().calls)
+
+    def __getitem__(self, item):  # pragma: no cover - compatibility
+        return _get_active_mock().calls[item]
+
+
+_state = {"mock": None}  # type: ignore[var-annotated]
+
+
+def _get_active_mock() -> _ResponsesMock:
+    mock_obj = _state.get("mock")
+    if mock_obj is None:
+        raise RuntimeError("responses mock is not active; use @responses.activate")
+    return mock_obj
+
+
+def add(method: str, url: str, **kwargs) -> None:
+    _get_active_mock().add(method, url, **kwargs)
+
+
+def activate(func: Optional[Callable] = None):
+    context = _ResponsesContext()
+    if func is None:
+        return context
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with context:
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+class _ResponsesContext:
+    def __init__(self) -> None:
+        self._mock = _ResponsesMock()
+
+    def __enter__(self) -> _ResponsesMock:
+        _state["mock"] = self._mock
+        return self._mock.__enter__()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            self._mock.__exit__(exc_type, exc, tb)
+        finally:
+            _state["mock"] = None
+
+
+calls = _CallsProxy()

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -1,0 +1,82 @@
+import logging
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+import responses
+
+# Allow importing scripts from the edge/scr directory.
+sys.path.append(str(ROOT / "edge" / "scr"))
+
+from sender import InfluxSender  # type: ignore  # noqa: E402
+
+
+WRITE_URL = "http://example.com/api/v2/write?org=org&bucket=bucket&precision=ns"
+
+
+@pytest.fixture(autouse=True)
+def _influx_env(monkeypatch):
+    monkeypatch.setenv("INFLUX_URL", "http://example.com")
+    monkeypatch.setenv("INFLUX_ORG", "org")
+    monkeypatch.setenv("INFLUX_BUCKET", "bucket")
+    monkeypatch.setenv("INFLUX_TOKEN", "token")
+    monkeypatch.setenv("INFLUX_BATCH_SIZE", "1")
+    monkeypatch.setenv("INFLUX_RETRY_MAX_ATTEMPTS", "3")
+    monkeypatch.setenv("INFLUX_RETRY_BASE_DELAY_S", "0")
+    monkeypatch.setenv("INFLUX_RETRY_MAX_BACKOFF_S", "0")
+    monkeypatch.setenv("INFLUX_TIMEOUT_S", "5")
+    yield
+    for key in list(os.environ):
+        if key.startswith("INFLUX_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+@responses.activate
+def test_send_retries_and_logs_server_error(caplog):
+    caplog.set_level(logging.DEBUG, logger="sender")
+    responses.add(responses.POST, WRITE_URL, status=500, headers={"Retry-After": "1"}, body="server error body")
+    responses.add(responses.POST, WRITE_URL, status=204)
+
+    sender = InfluxSender(start_worker=False)
+    sender._sleep = lambda _: None  # type: ignore[attr-defined]
+
+    try:
+        success = sender._send_with_retries(["m field=1 1"])  # type: ignore[arg-type]
+    finally:
+        sender.close()
+
+    assert success is True
+    assert len(responses.calls) == 2
+
+    failure_logs = [record.message for record in caplog.records if "failed" in record.message]
+    assert any("attempt 1/3" in msg for msg in failure_logs)
+    assert any("status=500" in msg for msg in failure_logs)
+    assert any("headers={'Retry-After': '1'}" in msg for msg in failure_logs)
+    assert any("body=server error body" in msg for msg in failure_logs)
+    assert any("succeeded after 2 attempts" in record.message for record in caplog.records)
+
+
+@responses.activate
+def test_send_aborts_on_unauthorized(caplog):
+    caplog.set_level(logging.DEBUG, logger="sender")
+    responses.add(responses.POST, WRITE_URL, status=401, body="Unauthorized")
+
+    sender = InfluxSender(start_worker=False)
+    sender._sleep = lambda _: None  # type: ignore[attr-defined]
+
+    try:
+        success = sender._send_with_retries(["m field=1 1"])  # type: ignore[arg-type]
+    finally:
+        sender.close()
+
+    assert success is False
+    assert len(responses.calls) == 1
+
+    error_logs = [record.message for record in caplog.records if record.levelno >= logging.ERROR]
+    assert any("HTTP 401" in msg for msg in error_logs)
+    assert any("attempt 1/3" in msg for msg in error_logs)


### PR DESCRIPTION
## Summary
- refactor the Influx sender worker to rely on a shared requests session, configurable batching, and exponential backoff with jitter
- capture HTTP failure details, avoid retrying irrecoverable 4xx responses, and document new environment toggles
- add a lightweight responses stub plus pytest coverage for 500/401 scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccf99585a483318d583ae4944ea87d