### PR TITLE
Add typed configuration models and migrate to YAML storage settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,31 +29,46 @@ source ~/venv-daq/bin/activate
 pip install -r requirements.txt
 ```
 
-## Configuración de `.env` y `sensors.yaml`
-### Credenciales de InfluxDB (`edge/.env`)
-1. Copie el ejemplo y edítelo con sus valores reales:
+## Configuración de `storage.yaml` y `sensors.yaml`
+### Migración automática desde `.env`
+Si ya tiene una instalación anterior basada en variables de entorno, ejecute el migrador para convertir los archivos existentes al nuevo esquema tipado:
+
+```bash
+cd ~/projects/raspi-mcc128-influx
+source ~/venv-daq/bin/activate
+python -m edge.config.migrate
+```
+
+El script reescribe `edge/config/sensors.yaml` con la nueva estructura y genera `edge/config/storage.yaml` a partir de las variables `INFLUX_*` definidas en `edge/.env` (si existen). Puede ejecutarlo tantas veces como quiera; si los archivos ya cumplen el nuevo formato no realizará cambios.
+
+### Credenciales de InfluxDB (`edge/config/storage.yaml`)
+1. Abra el archivo y complete los campos con sus valores reales:
    ```bash
    cd ~/projects/raspi-mcc128-influx/edge
-   cp .env.example .env
-   chmod 600 .env
-   nano .env  # ajuste INFLUX_URL, INFLUX_ORG, INFLUX_BUCKET, INFLUX_TOKEN y STATION_ID
+   nano config/storage.yaml  # ajuste url, org, bucket y token
    ```
-2. Verifique las credenciales antes de iniciar el servicio:
+2. Proteja las credenciales restringiendo los permisos:
+   ```bash
+   chmod 600 config/storage.yaml
+   ```
+3. Verifique la conectividad antes de iniciar el servicio:
    ```bash
    source ~/venv-daq/bin/activate
-   export $(grep -v '^#' .env | xargs)
-   curl --request GET "$INFLUX_URL/api/v2/buckets" \
-        --header "Authorization: Token $INFLUX_TOKEN" \
-        --header "Accept: application/json"
+   python - <<'PY'
+   from edge.config import load_storage_settings
+   cfg = load_storage_settings()
+   import requests
+   resp = requests.get(f"{cfg.url.rstrip('/')}/api/v2/buckets", headers={"Authorization": f"Token {cfg.token}"})
+   print(resp.status_code)
+   PY
    ```
-   Debe responder `200 OK`. Un `401` indica token/organización incorrectos.
+   Debe imprimir `200`. Un `401` indica token/organización incorrectos.
 
-3. Opcionalmente puede ajustar el comportamiento del envío agregando variables como `INFLUX_BATCH_SIZE`, `INFLUX_RETRY_MAX_ATTEMPTS`, `INFLUX_RETRY_BASE_DELAY_S` e `INFLUX_RETRY_MAX_BACKOFF_S` para controlar el tamaño del lote y la estrategia de reintentos (ver `.env.example`).
-> **Importante:** Nunca suba el archivo `.env` al repositorio. El archivo ya está listado en `.gitignore`, pero confirme con `git status` antes de hacer commits para evitar incluir credenciales por error.
+> **Importante:** `config/storage.yaml` contiene secretos. Evite subir los cambios al repositorio público y haga un respaldo seguro si necesita compartir el código.
 
 ### Rotación del token de InfluxDB
 1. Inicie sesión en la UI de InfluxDB y genere un token nuevo con permisos de lectura/escritura sobre el bucket correspondiente.
-2. Actualice el valor de `INFLUX_TOKEN` (y otros campos que hayan cambiado) en `edge/.env` y guarde el archivo.
+2. Actualice los campos de `config/storage.yaml` que hayan cambiado (`token`, `bucket`, etc.) y guarde el archivo.
 3. Reinicie el servicio o proceso que use estas credenciales:
    ```bash
    sudo systemctl restart edge.service
@@ -64,28 +79,30 @@ pip install -r requirements.txt
 Ajuste los canales, nombres, unidades y calibraciones según su montaje. Ejemplo incluido:
 ```yaml
 station_id: rpi5-a
-sample_rate_hz: 10
-scan_block_size: 50         # bloque de 5 s -> timeout dinámico = 5 s + 0.5 s de margen
-drift_detection:
-  correction_threshold_ns: 2000000   # corrige derivas mayores a 2 ms
+acquisition:
+  sample_rate_hz: 10
+  block_size: 50         # bloque de 5 s -> timeout dinámico = 5 s + 0.5 s de margen
+  duration_s:
+  drift_detection:
+    correction_threshold_ns: 2000000   # corrige derivas mayores a 2 ms
 channels:
-  - ch: 0
-    sensor: LVDT_P1
+  - index: 0
+    name: LVDT_P1
     unit: mm
-    v_range: 10
-    calib: {gain: 2.000, offset: -0.10}
-  - ch: 1
-    sensor: LVDT_P2
+    voltage_range: 10.0
+    calibration: {gain: 2.000, offset: -0.10}
+  - index: 1
+    name: LVDT_P2
     unit: mm
-    v_range: 10
-    calib: {gain: 2.000, offset: 0.00}
+    voltage_range: 10.0
+    calibration: {gain: 2.000, offset: 0.00}
 ```
 
 | Parámetro                 | Ubicación                           | Valor por defecto | Descripción |
 |---------------------------|-------------------------------------|-------------------|-------------|
-| `sample_rate_hz`          | `edge/config/sensors.yaml`          | `10` Hz           | Frecuencia de muestreo por canal (`fs`). Ajuste según la dinámica del sensor y el ancho de banda requerido.【F:edge/config/sensors.yaml†L1-L12】 |
-| `scan_block_size`         | `edge/config/sensors.yaml`          | `50` muestras     | Tamaño del bloque leído en cada iteración. Define la latencia (~5 s a 10 Hz) y se usa para calcular el timeout dinámico.【F:edge/config/sensors.yaml†L3-L8】【F:edge/scr/mcc_reader.py†L8-L33】 |
-| `drift_detection.correction_threshold_ns` | `edge/config/sensors.yaml` | `2_000_000` ns    | Umbral opcional para realinear el acumulador de timestamps con el reloj del sistema cuando la deriva supera ese valor. Si la desviación permanece por debajo, sólo se registran los valores observados.【F:edge/config/sensors.yaml†L3-L9】【F:edge/scr/acquire.py†L58-L96】 |
+| `acquisition.sample_rate_hz` | `edge/config/sensors.yaml`       | `10` Hz           | Frecuencia de muestreo por canal (`fs`). Ajuste según la dinámica del sensor y el ancho de banda requerido.【F:edge/config/sensors.yaml†L1-L18】 |
+| `acquisition.block_size`  | `edge/config/sensors.yaml`          | `50` muestras     | Tamaño del bloque leído en cada iteración. Define la latencia (~5 s a 10 Hz) y se usa para calcular el timeout dinámico.【F:edge/config/sensors.yaml†L1-L18】【F:edge/scr/mcc_reader.py†L8-L33】 |
+| `acquisition.drift_detection.correction_threshold_ns` | `edge/config/sensors.yaml` | `2_000_000` ns | Umbral opcional para realinear el acumulador de timestamps con el reloj del sistema cuando la deriva supera ese valor.【F:edge/config/sensors.yaml†L1-L18】【F:edge/scr/acquire.py†L70-L120】 |
 | `DEFAULT_TIMEOUT_MARGIN_S`| `edge/scr/mcc_reader.py`            | `0.5` s           | Margen extra sumado al tiempo esperado del bloque (`block_size/fs + margen`) para evitar timeouts espurios.【F:edge/scr/mcc_reader.py†L19-L35】 |
 
 ## Monitoreo de jitter y deriva
@@ -144,7 +161,7 @@ python scr/acquire.py
 sudo systemctl enable --now edge.service
 sudo systemctl status edge.service --no-pager
 ```
-Para aplicar cambios futuros (`.env`, `sensors.yaml` o código):
+Para aplicar cambios futuros (`storage.yaml`, `sensors.yaml` o código):
 ```bash
 sudo systemctl daemon-reload      # si cambió el unit file
 sudo systemctl restart edge.service
@@ -154,9 +171,15 @@ journalctl -u edge.service -f     # ver logs en vivo
 ## Validar conectividad desde la Pi
 ```bash
 source ~/venv-daq/bin/activate
-curl -f "$INFLUX_URL/health" || echo "Influx no responde"
+python - <<'PY'
+from edge.config import load_storage_settings
+import requests
+cfg = load_storage_settings()
+resp = requests.get(f"{cfg.url.rstrip('/')}/health", timeout=5)
+print(resp.json())
+PY
 ```
-Debe devolver `pass`. Si falla, verifique red/firewall y que la hora del sistema sea correcta (`timedatectl status`).
+Debe devolver `{"status": "pass"}`. Si falla, verifique red/firewall y que la hora del sistema sea correcta (`timedatectl status`).
 
 ## Uso de `deploy.sh`
 El script automatiza la actualización del código y la reinstalación de dependencias:
@@ -171,5 +194,5 @@ Pasos internos: `git fetch/reset` a `origin/main`, activa `~/venv-daq`, instala 
 - **InfluxDB responde 401 (Unauthorized)**: confirme `INFLUX_TOKEN`, `INFLUX_ORG` y permisos del token (`read/write` sobre el bucket). Repita la prueba `curl` de credenciales.
 - **Cortafuegos / puertos bloqueados**: asegure que el puerto de Influx (por defecto 8086) esté abierto desde la red de la Pi (`sudo ufw allow out 8086/tcp` o regla equivalente en el servidor).
 - **Desajuste horario / NTP**: la marca de tiempo se envía en nanosegundos. Configure NTP para evitar rechazos por timestamps futuros (`sudo timedatectl set-ntp true`).
-- **Falta de variables de entorno al ejecutar como servicio**: revise que `EnvironmentFile` apunte al `.env` correcto y reinicie el servicio tras cambios.【F:edge/scr/sender.py†L16-L44】【F:edge/service/edge.service†L7-L11】
+- **storage.yaml incompleto al ejecutar como servicio**: verifique que `edge/config/storage.yaml` contenga las credenciales correctas y que el servicio tenga permisos de lectura antes de reiniciarlo.【F:edge/config/storage.yaml†L1-L14】【F:edge/scr/sender.py†L24-L152】
 - **Overflow del buffer del MCC 128**: aumente `scan_block_size`, reduzca `sample_rate_hz` o mejore la conectividad a Influx para evitar colas llenas. Revise los mensajes de advertencia en `journalctl`.

--- a/edge/__init__.py
+++ b/edge/__init__.py
@@ -1,0 +1,2 @@
+"""Edge package exposing configuration and runtime helpers."""
+

--- a/edge/config/__init__.py
+++ b/edge/config/__init__.py
@@ -1,0 +1,27 @@
+"""Configuration schemas and persistence helpers for the edge collector."""
+
+from .schema import AcquisitionSettings, ChannelConfig, StationConfig, StorageSettings
+from .store import (
+    convert_legacy_station_payload,
+    default_storage_settings,
+    load_station_config,
+    load_storage_settings,
+    save_station_config,
+    save_storage_settings,
+    storage_settings_from_env,
+)
+
+__all__ = [
+    "AcquisitionSettings",
+    "ChannelConfig",
+    "StationConfig",
+    "StorageSettings",
+    "convert_legacy_station_payload",
+    "default_storage_settings",
+    "load_station_config",
+    "load_storage_settings",
+    "save_station_config",
+    "save_storage_settings",
+    "storage_settings_from_env",
+]
+

--- a/edge/config/migrate.py
+++ b/edge/config/migrate.py
@@ -1,0 +1,96 @@
+"""One-off helper to migrate legacy configuration files to the typed schema."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import (
+    default_storage_settings,
+    load_station_config,
+    load_storage_settings,
+    save_station_config,
+    save_storage_settings,
+    storage_settings_from_env,
+)
+from .store import CONFIG_DIR, load_env_file
+
+
+def migrate_station_config(path: Path) -> bool:
+    """Rewrite sensors.yaml using the canonical schema."""
+
+    try:
+        station = load_station_config(path)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"✗ No se pudo leer {path}: {exc}")
+        return False
+
+    save_station_config(station, path)
+    print(f"✓ Archivo {path.name} migrado al nuevo esquema")
+    return True
+
+
+def migrate_storage_config(path: Path, env_path: Path | None) -> bool:
+    """Ensure storage.yaml exists and follows the typed schema."""
+
+    if path.exists():
+        try:
+            load_storage_settings(path)
+        except ValueError as exc:
+            print(f"✗ storage.yaml existe pero es inválido: {exc}")
+            return False
+        print("✓ storage.yaml ya utiliza el nuevo formato; no se realizaron cambios")
+        return True
+
+    env_values = {}
+    if env_path and env_path.exists():
+        try:
+            env_values = dict(load_env_file(env_path))
+        except Exception as exc:  # pragma: no cover - optional dependency ausente
+            print(f"! No se pudo leer {env_path}: {exc}")
+
+    if env_values:
+        settings = storage_settings_from_env(env_values)
+        print(f"✓ Generando storage.yaml desde {env_path}")
+    else:
+        settings = default_storage_settings()
+        print("! No se encontraron credenciales; se generó un storage.yaml de ejemplo")
+
+    save_storage_settings(settings, path)
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config-dir",
+        type=Path,
+        default=CONFIG_DIR,
+        help="Directorio donde residen sensors.yaml y storage.yaml",
+    )
+    parser.add_argument(
+        "--env",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / ".env",
+        help="Ruta opcional a un archivo .env con credenciales de InfluxDB",
+    )
+    args = parser.parse_args(argv)
+
+    cfg_dir = args.config_dir
+    sensors_path = cfg_dir / "sensors.yaml"
+    storage_path = cfg_dir / "storage.yaml"
+
+    ok = True
+    if sensors_path.exists():
+        ok &= migrate_station_config(sensors_path)
+    else:
+        print(f"! {sensors_path} no existe; omitiendo migración de sensores")
+
+    ok &= migrate_storage_config(storage_path, args.env)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/edge/config/schema.py
+++ b/edge/config/schema.py
@@ -1,0 +1,292 @@
+"""Typed configuration models implemented with dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+
+def _as_str(value: Any, field_name: str, *, optional: bool = False) -> Optional[str]:
+    if value is None:
+        if optional:
+            return None
+        raise ValueError(f"'{field_name}' es obligatorio")
+    text = str(value).strip()
+    if not text and not optional:
+        raise ValueError(f"'{field_name}' no puede estar vacío")
+    return text or None
+
+
+def _as_int(value: Any, field_name: str) -> int:
+    if value is None:
+        raise ValueError(f"'{field_name}' es obligatorio")
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise ValueError(f"'{field_name}' debe ser un entero válido") from exc
+    return result
+
+
+def _as_float(value: Any, field_name: str) -> float:
+    if value is None:
+        raise ValueError(f"'{field_name}' es obligatorio")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise ValueError(f"'{field_name}' debe ser numérico") from exc
+    return result
+
+
+def _as_optional_float(value: Any, field_name: str) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    result = _as_float(value, field_name)
+    return result
+
+
+def _as_bool(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "si", "sí"}:
+        return True
+    if text in {"0", "false", "no"}:
+        return False
+    return default
+
+
+@dataclass
+class Calibration:
+    gain: float = 1.0
+    offset: float = 0.0
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "Calibration":
+        if not data:
+            return cls()
+        gain = _as_float(data.get("gain", 1.0), "calibration.gain")
+        offset = _as_float(data.get("offset", 0.0), "calibration.offset")
+        return cls(gain=gain, offset=offset)
+
+    def to_dict(self) -> Dict[str, float]:
+        return {"gain": self.gain, "offset": self.offset}
+
+
+@dataclass
+class DriftDetectionSettings:
+    correction_threshold_ns: Optional[int] = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "DriftDetectionSettings":
+        if not data:
+            return cls()
+        threshold_raw = data.get("correction_threshold_ns")
+        if threshold_raw is None or threshold_raw == "":
+            return cls()
+        threshold = _as_int(threshold_raw, "drift_detection.correction_threshold_ns")
+        if threshold < 0:
+            raise ValueError("drift_detection.correction_threshold_ns debe ser >= 0")
+        return cls(correction_threshold_ns=threshold)
+
+    def to_dict(self) -> Dict[str, Optional[int]]:
+        return {"correction_threshold_ns": self.correction_threshold_ns}
+
+
+@dataclass
+class AcquisitionSettings:
+    sample_rate_hz: float
+    block_size: int = 1000
+    duration_s: Optional[float] = None
+    drift_detection: DriftDetectionSettings = field(default_factory=DriftDetectionSettings)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "AcquisitionSettings":
+        sample_rate = _as_float(data.get("sample_rate_hz"), "sample_rate_hz")
+        if sample_rate <= 0:
+            raise ValueError("sample_rate_hz debe ser > 0")
+
+        block_raw = data.get("block_size", data.get("scan_block_size", 1000))
+        block_size = _as_int(block_raw, "block_size")
+        if block_size <= 0:
+            raise ValueError("block_size debe ser > 0")
+
+        duration = _as_optional_float(data.get("duration_s"), "duration_s")
+        if duration is not None and duration <= 0:
+            raise ValueError("duration_s debe ser > 0")
+
+        drift = DriftDetectionSettings.from_mapping(data.get("drift_detection"))
+        return cls(
+            sample_rate_hz=sample_rate,
+            block_size=block_size,
+            duration_s=duration,
+            drift_detection=drift,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "sample_rate_hz": self.sample_rate_hz,
+            "block_size": self.block_size,
+            "duration_s": self.duration_s,
+            "drift_detection": self.drift_detection.to_dict(),
+        }
+        return payload
+
+
+@dataclass
+class ChannelConfig:
+    index: int
+    name: str
+    unit: str
+    voltage_range: float
+    calibration: Calibration = field(default_factory=Calibration)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "ChannelConfig":
+        index = _as_int(data.get("index", data.get("ch")), "channels[].index")
+        if index < 0:
+            raise ValueError("channels[].index debe ser >= 0")
+        name = _as_str(data.get("name", data.get("sensor")), "channels[].name")
+        unit = _as_str(data.get("unit"), "channels[].unit")
+        voltage = _as_float(data.get("voltage_range", data.get("v_range")), "channels[].voltage_range")
+        if voltage <= 0:
+            raise ValueError("channels[].voltage_range debe ser > 0")
+        calibration = Calibration.from_mapping(data.get("calibration") or data.get("calib"))
+        return cls(index=index, name=name, unit=unit, voltage_range=voltage, calibration=calibration)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "index": self.index,
+            "name": self.name,
+            "unit": self.unit,
+            "voltage_range": self.voltage_range,
+            "calibration": self.calibration.to_dict(),
+        }
+
+
+@dataclass
+class StationConfig:
+    station_id: str
+    acquisition: AcquisitionSettings
+    channels: List[ChannelConfig] = field(default_factory=list)
+    description: Optional[str] = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "StationConfig":
+        station_id = _as_str(data.get("station_id"), "station_id")
+        description = _as_str(data.get("description"), "description", optional=True)
+        acquisition_payload = data.get("acquisition")
+        if not isinstance(acquisition_payload, Mapping):
+            raise ValueError("El bloque 'acquisition' es obligatorio")
+        acquisition = AcquisitionSettings.from_mapping(acquisition_payload)
+        channels_payload = data.get("channels") or []
+        if not isinstance(channels_payload, Iterable):
+            raise ValueError("channels debe ser una lista")
+        channels = [ChannelConfig.from_mapping(ch) for ch in channels_payload]
+        seen = set()
+        for channel in channels:
+            if channel.index in seen:
+                raise ValueError(f"canal duplicado: {channel.index}")
+            seen.add(channel.index)
+        return cls(station_id=station_id, acquisition=acquisition, channels=channels, description=description)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "station_id": self.station_id,
+            "acquisition": self.acquisition.to_dict(),
+            "channels": [ch.to_dict() for ch in self.channels],
+        }
+        if self.description:
+            payload["description"] = self.description
+        return payload
+
+
+@dataclass
+class RetrySettings:
+    max_attempts: int = 5
+    base_delay_s: float = 1.0
+    max_backoff_s: Optional[float] = 30.0
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "RetrySettings":
+        if not data:
+            return cls()
+        max_attempts = _as_int(data.get("max_attempts", 5), "retry.max_attempts")
+        if max_attempts < 1:
+            raise ValueError("retry.max_attempts debe ser >= 1")
+        base_delay = _as_float(data.get("base_delay_s", 1.0), "retry.base_delay_s")
+        if base_delay < 0:
+            raise ValueError("retry.base_delay_s debe ser >= 0")
+        max_backoff_raw = data.get("max_backoff_s", 30.0)
+        max_backoff = _as_optional_float(max_backoff_raw, "retry.max_backoff_s")
+        if max_backoff is not None and max_backoff < 0:
+            raise ValueError("retry.max_backoff_s debe ser >= 0")
+        return cls(max_attempts=max_attempts, base_delay_s=base_delay, max_backoff_s=max_backoff)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "max_attempts": self.max_attempts,
+            "base_delay_s": self.base_delay_s,
+            "max_backoff_s": self.max_backoff_s,
+        }
+
+
+@dataclass
+class StorageSettings:
+    driver: str
+    url: str
+    org: str
+    bucket: str
+    token: str
+    batch_size: int = 5
+    timeout_s: float = 5.0
+    queue_max_size: int = 1000
+    verify_ssl: bool = True
+    retry: RetrySettings = field(default_factory=RetrySettings)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "StorageSettings":
+        driver = _as_str(data.get("driver", "influxdb_v2"), "driver") or "influxdb_v2"
+        url = _as_str(data.get("url"), "url")
+        org = _as_str(data.get("org"), "org")
+        bucket = _as_str(data.get("bucket"), "bucket")
+        token = _as_str(data.get("token"), "token")
+        batch_size = _as_int(data.get("batch_size", 5), "batch_size")
+        if batch_size < 1:
+            raise ValueError("batch_size debe ser >= 1")
+        timeout_s = _as_float(data.get("timeout_s", 5.0), "timeout_s")
+        if timeout_s <= 0:
+            raise ValueError("timeout_s debe ser > 0")
+        queue_max_size = _as_int(data.get("queue_max_size", 1000), "queue_max_size")
+        if queue_max_size < 1:
+            raise ValueError("queue_max_size debe ser >= 1")
+        verify_ssl = _as_bool(data.get("verify_ssl"), True)
+        retry = RetrySettings.from_mapping(data.get("retry"))
+        return cls(
+            driver=driver,
+            url=url,
+            org=org,
+            bucket=bucket,
+            token=token,
+            batch_size=batch_size,
+            timeout_s=timeout_s,
+            queue_max_size=queue_max_size,
+            verify_ssl=verify_ssl,
+            retry=retry,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "driver": self.driver,
+            "url": self.url,
+            "org": self.org,
+            "bucket": self.bucket,
+            "token": self.token,
+            "batch_size": self.batch_size,
+            "timeout_s": self.timeout_s,
+            "queue_max_size": self.queue_max_size,
+            "verify_ssl": self.verify_ssl,
+            "retry": self.retry.to_dict(),
+        }
+

--- a/edge/config/sensors.yaml
+++ b/edge/config/sensors.yaml
@@ -1,16 +1,22 @@
 station_id: rpi5-a
-sample_rate_hz: 10
-scan_block_size: 50         # bloque de 5 s -> timeout dinámico = 5 s + 0.5 s de margen
-drift_detection:
-  correction_threshold_ns: 2000000   # corrige derivas >2 ms (opcional)
+acquisition:
+  sample_rate_hz: 10
+  block_size: 50
+  duration_s:
+  drift_detection:
+    correction_threshold_ns: 2000000
 channels:
-  - ch: 0
-    sensor: LVDT_P1
+  - index: 0
+    name: LVDT_P1
     unit: mm
-    v_range: 10             # ±10 V en MCC128
-    calib: {gain: 2.000, offset: -0.10}   # mm = gain*V + offset
-  - ch: 1
-    sensor: LVDT_P2
+    voltage_range: 10.0
+    calibration:
+      gain: 2.0
+      offset: -0.1
+  - index: 1
+    name: LVDT_P2
     unit: mm
-    v_range: 10
-    calib: {gain: 2.000, offset: 0.00}
+    voltage_range: 10.0
+    calibration:
+      gain: 2.0
+      offset: 0.0

--- a/edge/config/storage.yaml
+++ b/edge/config/storage.yaml
@@ -1,0 +1,14 @@
+# Configuración de almacenamiento (InfluxDB v2)
+driver: influxdb_v2
+url: http://localhost:8086
+org: example-org
+bucket: example-bucket
+token: replace-with-real-token
+batch_size: 5
+timeout_s: 5.0
+queue_max_size: 1000
+verify_ssl: true
+retry:
+  max_attempts: 5
+  base_delay_s: 1.0
+  max_backoff_s: 30.0

--- a/edge/config/store.py
+++ b/edge/config/store.py
@@ -1,0 +1,164 @@
+"""Helpers to load, validate and persist configuration files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+import yaml
+
+from .schema import StationConfig, StorageSettings
+
+try:  # pragma: no cover - optional dependency available in production only
+    from dotenv import dotenv_values
+except Exception:  # pragma: no cover - keep optional to avoid hard dependency at runtime
+    dotenv_values = None  # type: ignore[assignment]
+
+CONFIG_DIR = Path(__file__).resolve().parent
+
+
+def _read_yaml(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a mapping at {path}, found {type(data).__name__}")
+    return data
+
+
+def _write_yaml(path: Path, payload: Mapping[str, Any]):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(payload, fh, sort_keys=False, allow_unicode=True)
+
+
+def convert_legacy_station_payload(raw: Mapping[str, Any]) -> Dict[str, Any]:
+    """Convert the pre-2.0 sensors.yaml layout into the new schema payload."""
+
+    if "acquisition" in raw:
+        return dict(raw)
+
+    acquisition_payload: Dict[str, Any] = {
+        "sample_rate_hz": raw.get("sample_rate_hz"),
+        "scan_block_size": raw.get("scan_block_size"),
+        "duration_s": raw.get("duration_s"),
+    }
+
+    drift = raw.get("drift_detection")
+    if isinstance(drift, Mapping):
+        acquisition_payload["drift_detection"] = dict(drift)
+
+    converted_channels = []
+    for channel in raw.get("channels", []):
+        if not isinstance(channel, Mapping):
+            continue
+        converted_channels.append(
+            {
+                "ch": channel.get("ch", channel.get("index")),
+                "sensor": channel.get("sensor", channel.get("name")),
+                "unit": channel.get("unit"),
+                "v_range": channel.get("v_range", channel.get("voltage_range")),
+                "calib": channel.get("calib", channel.get("calibration", {})),
+            }
+        )
+
+    payload = {
+        "station_id": raw.get("station_id"),
+        "description": raw.get("description"),
+        "acquisition": acquisition_payload,
+        "channels": converted_channels,
+    }
+    return payload
+
+
+def load_station_config(path: Optional[Path] = None) -> StationConfig:
+    """Read and validate the station configuration from sensors.yaml."""
+
+    cfg_path = path or CONFIG_DIR / "sensors.yaml"
+    raw = _read_yaml(cfg_path)
+    payload = convert_legacy_station_payload(raw)
+    return StationConfig.from_mapping(payload)
+
+
+def save_station_config(config: StationConfig, path: Optional[Path] = None):
+    """Persist the station configuration using the canonical schema."""
+
+    cfg_path = path or CONFIG_DIR / "sensors.yaml"
+    payload = config.to_dict()
+    _write_yaml(cfg_path, payload)
+
+
+def load_storage_settings(path: Optional[Path] = None) -> StorageSettings:
+    """Read and validate storage settings from storage.yaml."""
+
+    cfg_path = path or CONFIG_DIR / "storage.yaml"
+    raw = _read_yaml(cfg_path)
+    return StorageSettings.from_mapping(raw)
+
+
+def save_storage_settings(settings: StorageSettings, path: Optional[Path] = None):
+    """Persist the storage settings to storage.yaml."""
+
+    cfg_path = path or CONFIG_DIR / "storage.yaml"
+    payload = settings.to_dict()
+    _write_yaml(cfg_path, payload)
+
+
+def storage_settings_from_env(env: Mapping[str, Any]) -> StorageSettings:
+    """Create storage settings from environment variables."""
+
+    retry_payload = {
+        "max_attempts": env.get("INFLUX_RETRY_MAX_ATTEMPTS"),
+        "base_delay_s": env.get("INFLUX_RETRY_BASE_DELAY_S"),
+        "max_backoff_s": env.get("INFLUX_RETRY_MAX_BACKOFF_S"),
+    }
+
+    payload = {
+        "driver": env.get("INFLUX_DRIVER", "influxdb_v2"),
+        "url": env.get("INFLUX_URL"),
+        "org": env.get("INFLUX_ORG"),
+        "bucket": env.get("INFLUX_BUCKET"),
+        "token": env.get("INFLUX_TOKEN"),
+        "batch_size": env.get("INFLUX_BATCH_SIZE"),
+        "timeout_s": env.get("INFLUX_TIMEOUT_S"),
+        "queue_max_size": env.get("INFLUX_QUEUE_MAX_SIZE"),
+        "retry": retry_payload,
+    }
+    verify_ssl = env.get("INFLUX_VERIFY_SSL", True)
+    if isinstance(verify_ssl, str):
+        verify_ssl = verify_ssl.strip().lower() not in {"0", "false", "no"}
+    payload["verify_ssl"] = verify_ssl
+    return StorageSettings.from_mapping(payload)
+
+
+def default_storage_settings() -> StorageSettings:
+    """Return a template storage configuration with placeholder values."""
+
+    payload = {
+        "driver": "influxdb_v2",
+        "url": "http://localhost:8086",
+        "org": "example-org",
+        "bucket": "example-bucket",
+        "token": "replace-with-real-token",
+        "batch_size": 5,
+        "timeout_s": 5.0,
+        "queue_max_size": 1000,
+        "verify_ssl": True,
+        "retry": {
+            "max_attempts": 5,
+            "base_delay_s": 1.0,
+            "max_backoff_s": 30.0,
+        },
+    }
+    return StorageSettings.from_mapping(payload)
+
+
+def load_env_file(path: Path) -> Mapping[str, str]:
+    """Load key/value pairs from a dotenv file."""
+
+    if dotenv_values is None:
+        raise RuntimeError("python-dotenv is required to parse .env files")
+    values = dotenv_values(str(path))  # type: ignore[operator]
+    return {k: v for k, v in values.items() if v is not None}
+

--- a/edge/service/edge.service
+++ b/edge/service/edge.service
@@ -6,8 +6,7 @@ Wants=network-online.target
 [Service]
 User=JJSI
 WorkingDirectory=/home/JJSI/projects/raspi-mcc128-influx/edge
-EnvironmentFile=/home/JJSI/projects/raspi-mcc128-influx/edge/.env
-ExecStart=/home/JJSI/venv-daq/bin/python /home/JJSI/projects/raspi-mcc128-influx/edge/src/acquire.py
+ExecStart=/home/JJSI/venv-daq/bin/python /home/JJSI/projects/raspi-mcc128-influx/edge/scr/acquire.py
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary
- replace the ad-hoc YAML parsing with dataclass-based configuration models and a store that reads `sensors.yaml` and the new `storage.yaml`
- add a migration utility and documentation so existing deployments can move from `.env` variables to the new schema
- update the acquisition loop, Influx sender and tests to consume the typed settings instead of reading environment variables directly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d0896f59108331b20648f8076a098a