### PR TITLE
Refactor acquisition flow into reusable runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ acquisition:
   sample_rate_hz: 10
   block_size: 50         # bloque de 5 s -> timeout dinámico = 5 s + 0.5 s de margen
   duration_s:
+  total_samples:
   drift_detection:
     correction_threshold_ns: 2000000   # corrige derivas mayores a 2 ms
 channels:
@@ -98,11 +99,17 @@ channels:
     calibration: {gain: 2.000, offset: 0.00}
 ```
 
+> **Nota:** la MCC128 aplica un único rango de entrada para todos los canales
+> habilitados. Configure el mismo `voltage_range` en cada canal; de lo
+> contrario la inicialización fallará con un error explicando la
+> limitación.【F:edge/scr/mcc_reader.py†L1-L71】
+
 | Parámetro                 | Ubicación                           | Valor por defecto | Descripción |
 |---------------------------|-------------------------------------|-------------------|-------------|
 | `acquisition.sample_rate_hz` | `edge/config/sensors.yaml`       | `10` Hz           | Frecuencia de muestreo por canal (`fs`). Ajuste según la dinámica del sensor y el ancho de banda requerido.【F:edge/config/sensors.yaml†L1-L18】 |
-| `acquisition.block_size`  | `edge/config/sensors.yaml`          | `50` muestras     | Tamaño del bloque leído en cada iteración. Define la latencia (~5 s a 10 Hz) y se usa para calcular el timeout dinámico.【F:edge/config/sensors.yaml†L1-L18】【F:edge/scr/mcc_reader.py†L8-L33】 |
-| `acquisition.drift_detection.correction_threshold_ns` | `edge/config/sensors.yaml` | `2_000_000` ns | Umbral opcional para realinear el acumulador de timestamps con el reloj del sistema cuando la deriva supera ese valor.【F:edge/config/sensors.yaml†L1-L18】【F:edge/scr/acquire.py†L70-L120】 |
+| `acquisition.block_size`  | `edge/config/sensors.yaml`          | `50` muestras     | Tamaño del bloque leído en cada iteración. Define la latencia (~5 s a 10 Hz) y se usa para calcular el timeout dinámico.【F:edge/config/sensors.yaml†L1-L18】【F:edge/scr/mcc_reader.py†L52-L94】 |
+| `acquisition.total_samples` | `edge/config/sensors.yaml`        | `null`            | Presupuesto máximo de muestras por canal. Activa el modo `timed` y detiene la adquisición tras alcanzarlo.【F:edge/config/sensors.yaml†L1-L18】【F:edge/scr/acquisition.py†L68-L126】 |
+| `acquisition.drift_detection.correction_threshold_ns` | `edge/config/sensors.yaml` | `2_000_000` ns | Umbral opcional para realinear el acumulador de timestamps con el reloj del sistema cuando la deriva supera ese valor.【F:edge/config/sensors.yaml†L1-L18】【F:edge/scr/acquisition.py†L68-L126】 |
 | `DEFAULT_TIMEOUT_MARGIN_S`| `edge/scr/mcc_reader.py`            | `0.5` s           | Margen extra sumado al tiempo esperado del bloque (`block_size/fs + margen`) para evitar timeouts espurios.【F:edge/scr/mcc_reader.py†L19-L35】 |
 
 ## Monitoreo de jitter y deriva

--- a/edge/config/schema.py
+++ b/edge/config/schema.py
@@ -99,6 +99,7 @@ class AcquisitionSettings:
     sample_rate_hz: float
     block_size: int = 1000
     duration_s: Optional[float] = None
+    total_samples: Optional[int] = None
     drift_detection: DriftDetectionSettings = field(default_factory=DriftDetectionSettings)
 
     @classmethod
@@ -116,11 +117,20 @@ class AcquisitionSettings:
         if duration is not None and duration <= 0:
             raise ValueError("duration_s debe ser > 0")
 
+        samples_raw = data.get("total_samples")
+        if samples_raw is None or samples_raw == "":
+            total_samples = None
+        else:
+            total_samples = _as_int(samples_raw, "total_samples")
+            if total_samples <= 0:
+                raise ValueError("total_samples debe ser > 0")
+
         drift = DriftDetectionSettings.from_mapping(data.get("drift_detection"))
         return cls(
             sample_rate_hz=sample_rate,
             block_size=block_size,
             duration_s=duration,
+            total_samples=total_samples,
             drift_detection=drift,
         )
 
@@ -129,6 +139,7 @@ class AcquisitionSettings:
             "sample_rate_hz": self.sample_rate_hz,
             "block_size": self.block_size,
             "duration_s": self.duration_s,
+            "total_samples": self.total_samples,
             "drift_detection": self.drift_detection.to_dict(),
         }
         return payload

--- a/edge/config/sensors.yaml
+++ b/edge/config/sensors.yaml
@@ -3,6 +3,7 @@ acquisition:
   sample_rate_hz: 10
   block_size: 50
   duration_s:
+  total_samples:
   drift_detection:
     correction_threshold_ns: 2000000
 channels:

--- a/edge/config/store.py
+++ b/edge/config/store.py
@@ -43,6 +43,7 @@ def convert_legacy_station_payload(raw: Mapping[str, Any]) -> Dict[str, Any]:
         "sample_rate_hz": raw.get("sample_rate_hz"),
         "scan_block_size": raw.get("scan_block_size"),
         "duration_s": raw.get("duration_s"),
+        "total_samples": raw.get("total_samples"),
     }
 
     drift = raw.get("drift_detection")

--- a/edge/scr/acquire.py
+++ b/edge/scr/acquire.py
@@ -1,76 +1,47 @@
 import logging
 import sys
 from pathlib import Path
-from time import time_ns
-
-from daqhats import AnalogInputRange
 
 # Ensure the repository root (edge parent) is importable when executed as script.
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from edge.config.store import load_station_config, load_storage_settings
 from edge.config.schema import StationConfig, StorageSettings
+from edge.config.store import load_station_config, load_storage_settings
 
+from acquisition import AcquisitionBlock, AcquisitionRunner, _consume_block_timestamps
 from calibrate import apply_calibration
-from mcc_reader import open_mcc128, read_block, start_scan
 from sender import InfluxSender, to_line
 
 
 logger = logging.getLogger(__name__)
 
 
-def _consume_block_timestamps(next_ts_ns: int, block_len: int, ts_step: int):
-    """Return timestamps for a block and the updated accumulator.
+def _build_block_handler(station_cfg: StationConfig, sender: InfluxSender):
+    pi = station_cfg.station_id
+    channels = station_cfg.channels
+    indices = [c.index for c in channels]
+    metadata = {
+        ch.index: (ch.name, ch.unit, ch.calibration.gain, ch.calibration.offset)
+        for ch in channels
+    }
 
-    Parameters
-    ----------
-    next_ts_ns:
-        Timestamp assigned to the first sample in the block.
-    block_len:
-        Number of samples in the block.
-    ts_step:
-        Nanoseconds between consecutive samples.
+    def handle_block(block: AcquisitionBlock) -> None:
+        timestamps = block.timestamps_ns
+        for ch in indices:
+            sensor, unit, gain, offset = metadata[ch]
+            values = apply_calibration(block.values_by_channel.get(ch, []), gain, offset)
+            for ts_ns, mm in zip(timestamps, values):
+                line = to_line(
+                    "lvdt",
+                    tags={"pi": pi, "canal": ch, "sensor": sensor, "unidad": unit},
+                    fields={"valor": float(mm)},
+                    ts_ns=ts_ns,
+                )
+                sender.enqueue(line)
 
-    Returns
-    -------
-    tuple[list[int], int]
-        The list of timestamps for each sample and the accumulator
-        advanced by ``block_len`` steps.
-    """
-
-    timestamps = [next_ts_ns + i * ts_step for i in range(block_len)]
-    return timestamps, next_ts_ns + block_len * ts_step
-
-RANGE_MAP = {
-    10.0: AnalogInputRange.BIP_10V,
-    5.0: AnalogInputRange.BIP_5V,
-    2.0: AnalogInputRange.BIP_2V,
-    1.0: AnalogInputRange.BIP_1V,
-}
-
-
-def _select_input_range(config: StationConfig) -> AnalogInputRange:
-    if not config.channels:
-        return AnalogInputRange.BIP_10V
-    ranges = {round(float(ch.voltage_range), 6) for ch in config.channels if ch.voltage_range}
-    if not ranges:
-        return AnalogInputRange.BIP_10V
-    if len(ranges) > 1:
-        logger.warning(
-            "Se configuraron múltiples rangos de voltaje %s; se usará el mayor disponible.",
-            sorted(ranges),
-        )
-    for value in sorted(ranges, reverse=True):
-        mapped = RANGE_MAP.get(value)
-        if mapped is not None:
-            return mapped
-    logger.warning(
-        "No se reconocen los rangos %s; se usará ±10 V por defecto.",
-        sorted(ranges),
-    )
-    return AnalogInputRange.BIP_10V
+    return handle_block
 
 
 def main(station: StationConfig | None = None, storage: StorageSettings | None = None):
@@ -80,94 +51,25 @@ def main(station: StationConfig | None = None, storage: StorageSettings | None =
     station_cfg = station or load_station_config()
     storage_cfg = storage or load_storage_settings()
 
-    pi = station_cfg.station_id
-    fs = station_cfg.acquisition.sample_rate_hz
-    chans = [c.index for c in station_cfg.channels]
-    block_size = station_cfg.acquisition.block_size
-    drift_cfg = station_cfg.acquisition.drift_detection
-    board = None
-    sender = None
+    sender = InfluxSender(storage_cfg)
     try:
-        board = open_mcc128()
-        ch_mask, block = start_scan(board, chans, fs, _select_input_range(station_cfg), block_size)
-        sender = InfluxSender(storage_cfg)
-        map_cal = {
-            ch.index: (ch.name, ch.unit, ch.calibration.gain, ch.calibration.offset)
-            for ch in station_cfg.channels
-        }
-
-        ts_step = int(1e9 / fs)
-        next_ts_ns = time_ns()
-        drift_threshold_ns = None
-        if drift_cfg.correction_threshold_ns is not None:
-            drift_threshold_ns = int(drift_cfg.correction_threshold_ns)
-
-        acquisition_deadline_ns = None
-        if station_cfg.acquisition.duration_s is not None:
-            acquisition_deadline_ns = next_ts_ns + int(station_cfg.acquisition.duration_s * 1e9)
-
-        while True:
-            if acquisition_deadline_ns is not None and time_ns() >= acquisition_deadline_ns:
-                logger.info("Duración de adquisición alcanzada; deteniendo la captura.")
-                break
-            raw = read_block(board, ch_mask, block, chans, sample_rate_hz=fs)
-            block_captured_ns = time_ns()
-            block_len = len(raw[chans[0]]) if chans else 0
-            if block_len == 0:
-                continue
-
-            timestamps, candidate_next_ts_ns = _consume_block_timestamps(next_ts_ns, block_len, ts_step)
-
-            # para cada canal, aplica calibración y envía cada muestra
-            for ch in chans:
-                sensor, unit, gain, offset = map_cal[ch]
-                vals = apply_calibration(raw[ch], gain, offset)
-                # empaqueta por muestra (si el volumen es alto, agrega por estadísticos por bloque)
-                for ts_ns, mm in zip(timestamps, vals):
-                    line = to_line(
-                        "lvdt",
-                        tags={"pi": pi, "canal": ch, "sensor": sensor, "unidad": unit},
-                        fields={"valor": float(mm)},
-                        ts_ns=ts_ns,
-                    )
-                    sender.enqueue(line)
-
-            expected_next_ts_ns = block_captured_ns + ts_step
-            drift_ns = expected_next_ts_ns - candidate_next_ts_ns
-            abs_drift_ns = abs(drift_ns)
-
-            if drift_threshold_ns is not None and abs_drift_ns > drift_threshold_ns:
-                logger.debug(
-                    "Deriva detectada tras bloque de %d muestras: ajuste %+d ns (%.3f ms)",
-                    block_len,
-                    drift_ns,
-                    drift_ns / 1e6,
-                )
-                next_ts_ns = expected_next_ts_ns
-            else:
-                next_ts_ns = candidate_next_ts_ns
-
-            logger.info(
-                "Bloque con %d muestras; desviación máxima %.3f ms (%d ns)",
-                block_len,
-                abs_drift_ns / 1e6,
-                abs_drift_ns,
-            )
-            if acquisition_deadline_ns is not None and block_captured_ns >= acquisition_deadline_ns:
-                logger.info("Duración de adquisición alcanzada tras enviar el bloque actual.")
-                break
+        handler = _build_block_handler(station_cfg, sender)
+        runner = AcquisitionRunner(
+            settings=station_cfg.acquisition,
+            channels=station_cfg.channels,
+            on_block=handler,
+        )
+        has_limits = (
+            station_cfg.acquisition.duration_s is not None
+            or station_cfg.acquisition.total_samples is not None
+        )
+        mode = "timed" if has_limits else "continuous"
+        runner.run(mode=mode)
     except KeyboardInterrupt:
-        pass
+        logger.info("Adquisición interrumpida por el usuario.")
     finally:
-        if sender is not None:
-            sender.close()
-        if board is not None:
-            stop_scan = getattr(board, "a_in_scan_stop", None)
-            if callable(stop_scan):
-                stop_scan()
-            cleanup_scan = getattr(board, "a_in_scan_cleanup", None)
-            if callable(cleanup_scan):
-                cleanup_scan()
+        sender.close()
+
 
 if __name__ == "__main__":
     main()

--- a/edge/scr/acquisition.py
+++ b/edge/scr/acquisition.py
@@ -1,0 +1,166 @@
+"""High-level acquisition runner orchestrating MCC128 scans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from time import time_ns
+from typing import Callable, Dict, List, Optional, Sequence
+
+from edge.config.schema import AcquisitionSettings, ChannelConfig
+
+from mcc_reader import open_mcc128, read_block, start_scan
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AcquisitionBlock:
+    """Bundle of raw samples captured in a single MCC128 read."""
+
+    timestamps_ns: List[int]
+    values_by_channel: Dict[int, List[float]]
+    captured_at_ns: int
+
+
+def _consume_block_timestamps(next_ts_ns: int, block_len: int, ts_step: int) -> tuple[List[int], int]:
+    """Return timestamps for a block and the updated accumulator."""
+
+    timestamps = [next_ts_ns + i * ts_step for i in range(block_len)]
+    return timestamps, next_ts_ns + block_len * ts_step
+
+
+class AcquisitionRunner:
+    """Coordinate MCC128 scans and deliver blocks to the provided callback."""
+
+    def __init__(
+        self,
+        settings: AcquisitionSettings,
+        channels: Sequence[ChannelConfig],
+        *,
+        on_block: Callable[[AcquisitionBlock], None],
+    ) -> None:
+        if not callable(on_block):  # pragma: no cover - defensive
+            raise TypeError("on_block must be callable")
+        self.settings = settings
+        self.channels = list(channels)
+        self._on_block = on_block
+        self._stop_requested = False
+
+    def request_stop(self) -> None:
+        """Signal the runner to stop after completing the current iteration."""
+
+        self._stop_requested = True
+
+    def run(self, mode: str = "continuous") -> None:
+        """Start the acquisition loop until completion or stop request."""
+
+        if mode not in {"continuous", "timed"}:
+            raise ValueError(f"Unsupported acquisition mode: {mode}")
+
+        board = None
+        ch_mask = 0
+        try:
+            board = open_mcc128()
+            channel_indices = [ch.index for ch in self.channels]
+            if not channel_indices:
+                logger.warning("No hay canales configurados; se omite la adquisición.")
+                return
+            channel_ranges = {ch.index: ch.voltage_range for ch in self.channels}
+            ch_mask, block_samples = start_scan(
+                board,
+                channel_indices,
+                self.settings.sample_rate_hz,
+                channel_ranges=channel_ranges,
+                block_samples=self.settings.block_size,
+            )
+
+            ts_step = int(1e9 / self.settings.sample_rate_hz)
+            next_ts_ns = time_ns()
+            drift_raw = self.settings.drift_detection.correction_threshold_ns
+            drift_threshold_ns = int(drift_raw) if drift_raw is not None else None
+
+            acquisition_deadline_ns: Optional[int] = None
+            if mode == "timed" and self.settings.duration_s is not None:
+                acquisition_deadline_ns = next_ts_ns + int(self.settings.duration_s * 1e9)
+
+            remaining_samples: Optional[int] = None
+            if mode == "timed" and self.settings.total_samples is not None:
+                remaining_samples = int(self.settings.total_samples)
+
+            while True:
+                if self._stop_requested:
+                    logger.info("Stop requested; ending acquisition loop.")
+                    break
+                if acquisition_deadline_ns is not None and time_ns() >= acquisition_deadline_ns:
+                    logger.info("Acquisition duration exhausted; stopping scan.")
+                    break
+
+                raw = read_block(
+                    board,
+                    ch_mask,
+                    block_samples,
+                    channel_indices,
+                    sample_rate_hz=self.settings.sample_rate_hz,
+                )
+                block_captured_ns = time_ns()
+                block_len = len(raw[channel_indices[0]]) if channel_indices else 0
+                if block_len == 0:
+                    continue
+
+                if remaining_samples is not None and block_len > remaining_samples:
+                    block_len = remaining_samples
+                    raw = {ch: vals[:block_len] for ch, vals in raw.items()}
+
+                timestamps, candidate_next_ts_ns = _consume_block_timestamps(
+                    next_ts_ns, block_len, ts_step
+                )
+
+                block = AcquisitionBlock(
+                    timestamps_ns=timestamps,
+                    values_by_channel=raw,
+                    captured_at_ns=block_captured_ns,
+                )
+                self._on_block(block)
+
+                expected_next_ts_ns = block_captured_ns + ts_step
+                drift_ns = expected_next_ts_ns - candidate_next_ts_ns
+                abs_drift_ns = abs(drift_ns)
+
+                if drift_threshold_ns is not None and abs_drift_ns > drift_threshold_ns:
+                    logger.debug(
+                        "Deriva detectada tras bloque de %d muestras: ajuste %+d ns (%.3f ms)",
+                        block_len,
+                        drift_ns,
+                        drift_ns / 1e6,
+                    )
+                    next_ts_ns = expected_next_ts_ns
+                else:
+                    next_ts_ns = candidate_next_ts_ns
+
+                logger.info(
+                    "Bloque con %d muestras; desviación máxima %.3f ms (%d ns)",
+                    block_len,
+                    abs_drift_ns / 1e6,
+                    abs_drift_ns,
+                )
+
+                if remaining_samples is not None:
+                    remaining_samples -= block_len
+                    if remaining_samples <= 0:
+                        logger.info("Sample budget exhausted; stopping scan.")
+                        break
+                if (
+                    acquisition_deadline_ns is not None
+                    and block_captured_ns >= acquisition_deadline_ns
+                ):
+                    logger.info("Acquisition duration exhausted after delivering block.")
+                    break
+        finally:
+            if board is not None:
+                stop_scan = getattr(board, "a_in_scan_stop", None)
+                if callable(stop_scan):
+                    stop_scan()
+                cleanup_scan = getattr(board, "a_in_scan_cleanup", None)
+                if callable(cleanup_scan):
+                    cleanup_scan()

--- a/edge/scr/mcc_reader.py
+++ b/edge/scr/mcc_reader.py
@@ -1,33 +1,112 @@
-from daqhats import mcc128, OptionFlags, HatIDs, hat_list, AnalogInputMode, AnalogInputRange
+"""Helpers to interface with the MCC128 DAQ board."""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from daqhats import (
+    AnalogInputMode,
+    AnalogInputRange,
+    HatIDs,
+    OptionFlags,
+    hat_list,
+    mcc128,
+)
+
+RANGE_MAP = {
+    10.0: AnalogInputRange.BIP_10V,
+    5.0: AnalogInputRange.BIP_5V,
+    2.0: AnalogInputRange.BIP_2V,
+    1.0: AnalogInputRange.BIP_1V,
+}
+
 
 def open_mcc128():
     hats = hat_list(HatIDs.MCC_128)
-    if not hats: raise RuntimeError("No se encontró MCC128")
+    if not hats:
+        raise RuntimeError("No se encontró MCC128")
     return mcc128(hats[0].address)
 
-def start_scan(board, channels, fs_hz, v_range=AnalogInputRange.BIP_10V, block_samples=1000):
+
+def _coerce_voltage_range(value: float | AnalogInputRange) -> AnalogInputRange:
+    if isinstance(value, AnalogInputRange):
+        return value
+    mapped = RANGE_MAP.get(round(float(value), 6))
+    if mapped is None:
+        raise ValueError(
+            f"Rango de voltaje {value!r} no soportado; valores válidos: {sorted(RANGE_MAP)}"
+        )
+    return mapped
+
+
+def resolve_input_range(
+    channel_ranges: Mapping[int, float | AnalogInputRange] | Sequence[float | AnalogInputRange] | None,
+    *,
+    default: AnalogInputRange = AnalogInputRange.BIP_10V,
+) -> AnalogInputRange:
+    """Resolve the AnalogInputRange to apply to the MCC128 scan.
+
+    The MCC128 applies the same voltage range to every enabled channel. When
+    the configuration requests different ranges the function raises a
+    ValueError, documenting the hardware limitation to avoid silent
+    misconfigurations.
+    """
+
+    if not channel_ranges:
+        return default
+
+    if isinstance(channel_ranges, Mapping):
+        requested = [_coerce_voltage_range(value) for value in channel_ranges.values()]
+    else:
+        requested = [_coerce_voltage_range(value) for value in channel_ranges]
+
+    unique = {item for item in requested}
+    if not unique:
+        return default
+    if len(unique) > 1:
+        raise ValueError(
+            "MCC128 solo admite un rango de entrada global; se recibieron múltiples valores: "
+            + ", ".join(sorted({rng.name for rng in unique}))
+        )
+    return unique.pop()
+
+
+def start_scan(
+    board,
+    channels: Sequence[int],
+    fs_hz: float,
+    *,
+    channel_ranges: Mapping[int, float | AnalogInputRange] | Sequence[float | AnalogInputRange] | None = None,
+    block_samples: int = 1000,
+):
     ch_mask = 0
-    for ch in channels: ch_mask |= 1 << ch
-    board.a_in_mode_write(AnalogInputMode.DIFFERENTIAL)  # usa DIFF si tu cableado lo permite
-    board.a_in_range_write(v_range)
+    for ch in channels:
+        ch_mask |= 1 << ch
+    board.a_in_mode_write(AnalogInputMode.DIFFERENTIAL)
+    board.a_in_range_write(resolve_input_range(channel_ranges))
     board.a_in_scan_start(
         channel_mask=ch_mask,
-        samples_per_channel=0,               # 0 = continuo
+        samples_per_channel=0,
         sample_rate_per_channel=fs_hz,
-        options=OptionFlags.CONTINUOUS
+        options=OptionFlags.CONTINUOUS,
     )
     return ch_mask, block_samples
 
+
 DEFAULT_TIMEOUT_MARGIN_S = 0.5
 
-def read_block(board, ch_mask, block_samples, channels, timeout=None, sample_rate_hz=None, safety_margin_s=DEFAULT_TIMEOUT_MARGIN_S):
-    """Lee un bloque de muestras del MCC128.
 
-    Si ``timeout`` no se provee, se calcula como la duración esperada del
-    bloque (``block_samples / sample_rate_hz``) más un margen de seguridad
-    ``safety_margin_s``. Esto evita un valor fijo que pudiera resultar muy
-    corto cuando se cambia ``block_samples`` o la frecuencia de muestreo.
-    """
+def read_block(
+    board,
+    ch_mask,
+    block_samples,
+    channels,
+    timeout=None,
+    sample_rate_hz=None,
+    safety_margin_s=DEFAULT_TIMEOUT_MARGIN_S,
+):
+    """Lee un bloque de muestras del MCC128."""
+
     if timeout is None:
         if sample_rate_hz is None or sample_rate_hz <= 0:
             raise ValueError("Se requiere sample_rate_hz para calcular timeout dinámico")
@@ -37,8 +116,6 @@ def read_block(board, ch_mask, block_samples, channels, timeout=None, sample_rat
     data = board.a_in_scan_read(block_samples, timeout)
     if data.hardware_overrun or data.buffer_overrun:
         raise RuntimeError("Overrun de hardware/buffer")
-    # data.data -> lista intercalada por canal
-    # reacomoda a dict canal->lista
     out = {ch: [] for ch in channels}
     for i, val in enumerate(data.data):
         channel = channels[i % len(channels)]


### PR DESCRIPTION
## Summary
- add an AcquisitionRunner orchestration class that supports continuous and timed capture modes with stop requests
- adjust the CLI wrapper to use the runner and push blocks through the existing Influx sender
- validate voltage ranges per channel, extend configuration with total_samples, and document the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08e4f54dc8331b92a8e82060092ae