### PR TITLE
Add acquisition test mode preview broadcast

### DIFF
--- a/edge/scr/acquisition.py
+++ b/edge/scr/acquisition.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 from time import time_ns
-from typing import Callable, Dict, List, Optional, Sequence
+from typing import Callable, Dict, List, Optional, Protocol, Sequence, runtime_checkable
 
 from edge.config.schema import StationConfig, StorageSettings
 
@@ -23,6 +23,41 @@ class AcquisitionBlock:
     timestamps_ns: List[int]
     values_by_channel: Dict[int, List[float]]
     captured_at_ns: int
+
+
+@dataclass(frozen=True)
+class CalibratedChannelBlock:
+    """Calibrated samples for a single channel inside a block."""
+
+    index: int
+    name: str
+    unit: str
+    values: List[float]
+
+
+@dataclass(frozen=True)
+class CalibratedBlock:
+    """Calibrated representation of a block ready for preview broadcasting."""
+
+    station_id: str
+    timestamps_ns: List[int]
+    channels: Dict[int, CalibratedChannelBlock]
+    captured_at_ns: int
+
+
+PreviewMessage = Optional[CalibratedBlock]
+
+
+@runtime_checkable
+class _SupportsPutNowait(Protocol):
+    def put_nowait(self, item: PreviewMessage) -> None:  # pragma: no cover - Protocol signature
+        """Queue-like interface supporting put_nowait."""
+
+
+@runtime_checkable
+class _SupportsPublish(Protocol):
+    def publish(self, item: PreviewMessage) -> None:  # pragma: no cover - Protocol signature
+        """Pub/sub style interface."""
 
 
 def _consume_block_timestamps(next_ts_ns: int, block_len: int, ts_step: int) -> tuple[List[int], int]:
@@ -49,21 +84,45 @@ class AcquisitionRunner:
         self._sink_factory = sink_factory
         self._stop_requested = False
         self._active_sinks: Sequence[SampleSink] = ()
+        self._broadcast_channel: Optional[_SupportsPutNowait | _SupportsPublish] = None
+        self._test_mode_active = False
+        self._test_blocks_broadcast = 0
+        self._test_samples_broadcast = 0
 
     def request_stop(self) -> None:
         """Signal the runner to stop after completing the current iteration."""
 
         self._stop_requested = True
 
-    def run(self, mode: str = "continuous") -> None:
+    def run(
+        self,
+        mode: str = "continuous",
+        *,
+        test_channel: Optional[_SupportsPutNowait | _SupportsPublish] = None,
+    ) -> None:
         """Start the acquisition loop until completion or stop request."""
 
-        if mode not in {"continuous", "timed"}:
+        if mode not in {"continuous", "timed", "test"}:
             raise ValueError(f"Unsupported acquisition mode: {mode}")
+
+        self._broadcast_channel = test_channel if mode == "test" else None
+        self._test_mode_active = mode == "test"
+        self._test_blocks_broadcast = 0
+        self._test_samples_broadcast = 0
+        if self._test_mode_active and self._broadcast_channel is None:
+            logger.warning(
+                "Modo test activado sin canal de publicación; no se emitirá vista previa."
+            )
 
         board = None
         ch_mask = 0
-        self._active_sinks = self._initialize_sinks()
+        if self._test_mode_active:
+            self._active_sinks = ()
+            logger.info(
+                "Modo test habilitado: se omite la inicialización de sinks de almacenamiento."
+            )
+        else:
+            self._active_sinks = self._initialize_sinks()
         try:
             board = open_mcc128()
             channel_indices = [ch.index for ch in self.channels]
@@ -85,11 +144,12 @@ class AcquisitionRunner:
             drift_threshold_ns = int(drift_raw) if drift_raw is not None else None
 
             acquisition_deadline_ns: Optional[int] = None
-            if mode == "timed" and self.settings.duration_s is not None:
+            timed_mode = mode in {"timed", "test"}
+            if timed_mode and self.settings.duration_s is not None:
                 acquisition_deadline_ns = next_ts_ns + int(self.settings.duration_s * 1e9)
 
             remaining_samples: Optional[int] = None
-            if mode == "timed" and self.settings.total_samples is not None:
+            if timed_mode and self.settings.total_samples is not None:
                 remaining_samples = int(self.settings.total_samples)
 
             while True:
@@ -169,6 +229,16 @@ class AcquisitionRunner:
                 cleanup_scan = getattr(board, "a_in_scan_cleanup", None)
                 if callable(cleanup_scan):
                     cleanup_scan()
+            if self._test_mode_active:
+                self._publish_preview_block(None)
+                if self._test_blocks_broadcast or self._test_samples_broadcast:
+                    logger.info(
+                        "Modo test finalizado: %d bloques y %d muestras emitidas para vista previa.",
+                        self._test_blocks_broadcast,
+                        self._test_samples_broadcast,
+                    )
+            self._broadcast_channel = None
+            self._test_mode_active = False
 
     # Internal helpers --------------------------------------------------------
     def _initialize_sinks(self) -> Sequence[SampleSink]:
@@ -197,33 +267,52 @@ class AcquisitionRunner:
         self._active_sinks = ()
 
     def _handle_block(self, block: AcquisitionBlock) -> None:
-        if not self._active_sinks:
+        should_broadcast = self._test_mode_active and self._broadcast_channel is not None
+        if not self._active_sinks and not should_broadcast:
             return
         station_id = self.station.station_id
+        calibrated_channels: Dict[int, CalibratedChannelBlock] = {}
         for channel in self.channels:
             values = block.values_by_channel.get(channel.index, [])
             calibrated = apply_calibration(values, channel.calibration.gain, channel.calibration.offset)
-            for ts_ns, value in zip(block.timestamps_ns, calibrated):
-                tags = {
-                    "pi": station_id,
-                    "sensor": channel.name,
-                    "unidad": channel.unit,
-                    "canal": channel.index,
-                }
-                metadata = {
-                    "measurement": "lvdt",
-                    "tags": tags,
-                    "station_id": station_id,
-                    "sensor_name": channel.name,
-                    "unit": channel.unit,
-                }
-                sample = Sample(
-                    channel=channel.index,
-                    timestamp_ns=ts_ns,
-                    calibrated_values={"valor": float(value)},
-                    metadata=metadata,
+            if calibrated:
+                calibrated_channels[channel.index] = CalibratedChannelBlock(
+                    index=channel.index,
+                    name=channel.name,
+                    unit=channel.unit,
+                    values=[float(value) for value in calibrated],
                 )
-                self._dispatch_sample(sample)
+            if self._active_sinks:
+                for ts_ns, value in zip(block.timestamps_ns, calibrated):
+                    tags = {
+                        "pi": station_id,
+                        "sensor": channel.name,
+                        "unidad": channel.unit,
+                        "canal": channel.index,
+                    }
+                    metadata = {
+                        "measurement": "lvdt",
+                        "tags": tags,
+                        "station_id": station_id,
+                        "sensor_name": channel.name,
+                        "unit": channel.unit,
+                    }
+                    sample = Sample(
+                        channel=channel.index,
+                        timestamp_ns=ts_ns,
+                        calibrated_values={"valor": float(value)},
+                        metadata=metadata,
+                    )
+                    self._dispatch_sample(sample)
+
+        if should_broadcast and calibrated_channels:
+            preview_block = CalibratedBlock(
+                station_id=station_id,
+                timestamps_ns=list(block.timestamps_ns),
+                channels=calibrated_channels,
+                captured_at_ns=block.captured_at_ns,
+            )
+            self._publish_preview_block(preview_block)
 
     def _dispatch_sample(self, sample: Sample) -> None:
         for sink in self._active_sinks:
@@ -231,3 +320,41 @@ class AcquisitionRunner:
                 sink.handle_sample(sample)
             except Exception:  # pragma: no cover - registro de errores
                 logger.exception("Sink %r rechazó la muestra", sink)
+
+    def _publish_preview_block(self, block: PreviewMessage) -> None:
+        channel = self._broadcast_channel
+        if channel is None:
+            return
+        try:
+            if isinstance(channel, _SupportsPutNowait):
+                channel.put_nowait(block)
+            elif isinstance(channel, _SupportsPublish):
+                channel.publish(block)
+            else:
+                raise TypeError(
+                    f"El canal de broadcast no implementa put_nowait/publish: {type(channel)!r}"
+                )
+        except Exception:
+            logger.exception("Error al publicar bloque de vista previa")
+            return
+
+        if block is None:
+            logger.debug("Señal de finalización enviada al canal de vista previa.")
+            return
+
+        self._test_blocks_broadcast += 1
+        samples = sum(len(ch.values) for ch in block.channels.values())
+        self._test_samples_broadcast += samples
+        queue_size = "n/a"
+        qsize = getattr(channel, "qsize", None)
+        if callable(qsize):
+            try:
+                queue_size = qsize()
+            except Exception:  # pragma: no cover - métricas best effort
+                queue_size = "n/a"
+        logger.debug(
+            "Bloque de vista previa #%d emitido con %d muestras (qsize=%s)",
+            self._test_blocks_broadcast,
+            samples,
+            queue_size,
+        )

--- a/edge/scr/preview.py
+++ b/edge/scr/preview.py
@@ -1,0 +1,151 @@
+"""Async helpers to consume calibrated blocks and expose preview payloads."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import logging
+from typing import AsyncIterator, Iterable, List, Optional, Sequence
+
+from edge.config.schema import ChannelConfig, StationConfig
+
+from acquisition import CalibratedBlock, CalibratedChannelBlock
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PreviewOptions:
+    """Runtime configuration for preview streaming."""
+
+    channels: Optional[Sequence[int]] = None
+    max_duration_s: Optional[float] = None
+    downsample: int = 1
+
+    def normalized_downsample(self) -> int:
+        step = int(self.downsample) if self.downsample is not None else 1
+        if step < 1:
+            logger.warning("Downsample <1 (%s) recibido; se ajusta a 1.", step)
+            return 1
+        return step
+
+
+def _ack_queue(queue: asyncio.Queue[Optional[CalibratedBlock]]) -> None:
+    task_done = getattr(queue, "task_done", None)
+    if callable(task_done):  # pragma: no branch - simple guard
+        try:
+            task_done()
+        except ValueError:  # pragma: no cover - join() not in use
+            pass
+
+
+def _select_channels(station: StationConfig, requested: Optional[Sequence[int]]) -> List[ChannelConfig]:
+    if not requested:
+        return list(station.channels)
+    mapping = {channel.index: channel for channel in station.channels}
+    selected: List[ChannelConfig] = []
+    seen = set()
+    for raw_idx in requested:
+        idx = int(raw_idx)
+        if idx in seen:
+            continue
+        seen.add(idx)
+        if idx not in mapping:
+            raise ValueError(f"Canal {idx} no está configurado en la estación")
+        selected.append(mapping[idx])
+    return selected
+
+
+def _filter_block(
+    block: CalibratedBlock,
+    channels: Iterable[ChannelConfig],
+    *,
+    downsample: int,
+) -> Optional[tuple[List[int], List[CalibratedChannelBlock]]]:
+    timestamps = block.timestamps_ns[::downsample]
+    if not timestamps:
+        return None
+    selected_channels: List[CalibratedChannelBlock] = []
+    for channel_cfg in channels:
+        channel_data = block.channels.get(channel_cfg.index)
+        if channel_data is None:
+            continue
+        values = channel_data.values[::downsample]
+        if not values:
+            continue
+        selected_channels.append(
+            CalibratedChannelBlock(
+                index=channel_data.index,
+                name=channel_data.name,
+                unit=channel_data.unit,
+                values=values,
+            )
+        )
+    if not selected_channels:
+        return None
+    return timestamps, selected_channels
+
+
+async def stream_preview(
+    queue: "asyncio.Queue[Optional[CalibratedBlock]]",
+    station: StationConfig,
+    *,
+    options: Optional[PreviewOptions] = None,
+) -> AsyncIterator[dict]:
+    """Yield preview payloads until the queue provides a sentinel or duration limit."""
+
+    opts = options or PreviewOptions()
+    if opts.max_duration_s is not None and opts.max_duration_s <= 0:
+        raise ValueError("max_duration_s debe ser > 0")
+
+    downsample = opts.normalized_downsample()
+    selected_channels = _select_channels(station, opts.channels)
+
+    start_ts_ns: Optional[int] = None
+    delivered_duration_ns = 0
+
+    while True:
+        block = await queue.get()
+        try:
+            if block is None:
+                logger.debug("Cola de vista previa recibió señal de cierre.")
+                break
+
+            filtered = _filter_block(block, selected_channels, downsample=downsample)
+            if filtered is None:
+                continue
+            timestamps, channels_payload = filtered
+            payload = {
+                "station_id": block.station_id,
+                "captured_at_ns": block.captured_at_ns,
+                "timestamps_ns": timestamps,
+                "channels": [
+                    {
+                        "index": channel.index,
+                        "name": channel.name,
+                        "unit": channel.unit,
+                        "values": channel.values,
+                    }
+                    for channel in channels_payload
+                ],
+            }
+            yield payload
+
+            if opts.max_duration_s is not None:
+                if start_ts_ns is None:
+                    start_ts_ns = timestamps[0]
+                delivered_duration_ns = timestamps[-1] - start_ts_ns
+                if delivered_duration_ns >= opts.max_duration_s * 1e9:
+                    logger.info(
+                        "Duración máxima de vista previa alcanzada (%.2f s); se detiene el stream.",
+                        opts.max_duration_s,
+                    )
+                    break
+        finally:
+            _ack_queue(queue)
+
+    logger.debug(
+        "Stream de vista previa finalizado tras %.3f s y downsample=%d.",
+        delivered_duration_ns / 1e9 if delivered_duration_ns else 0.0,
+        downsample,
+    )

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,169 @@
+import asyncio
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCR_PATH = ROOT / "edge" / "scr"
+if str(SCR_PATH) not in sys.path:
+    sys.path.append(str(SCR_PATH))
+
+from acquisition import AcquisitionRunner, CalibratedBlock, CalibratedChannelBlock  # type: ignore  # noqa: E402
+from edge.config.schema import (  # type: ignore  # noqa: E402
+    AcquisitionSettings,
+    Calibration,
+    ChannelConfig,
+    StationConfig,
+    StorageSettings,
+)
+from preview import PreviewOptions, stream_preview  # type: ignore  # noqa: E402
+
+
+def _make_station(total_samples: int = 4) -> StationConfig:
+    acquisition = AcquisitionSettings(
+        sample_rate_hz=10.0,
+        block_size=2,
+        duration_s=None,
+        total_samples=total_samples,
+    )
+    channel = ChannelConfig(
+        index=0,
+        name="LVDT",
+        unit="mm",
+        voltage_range=10.0,
+        calibration=Calibration(gain=2.0, offset=1.0),
+    )
+    return StationConfig(station_id="station", acquisition=acquisition, channels=[channel])
+
+
+def _make_storage() -> StorageSettings:
+    return StorageSettings(
+        driver="influxdb_v2",
+        url="http://example.com",
+        org="org",
+        bucket="bucket",
+        token="token",
+    )
+
+
+def test_acquisition_runner_broadcasts_calibrated_blocks(monkeypatch):
+    station = _make_station(total_samples=4)
+    storage = _make_storage()
+    queue: "asyncio.Queue[CalibratedBlock | None]" = asyncio.Queue()
+
+    fake_board = object()
+    monkeypatch.setattr("acquisition.open_mcc128", lambda: fake_board)
+
+    def fake_start_scan(board, channels, fs_hz, channel_ranges=None, block_samples=None):
+        assert board is fake_board
+        return 0b1, block_samples or station.acquisition.block_size
+
+    monkeypatch.setattr("acquisition.start_scan", fake_start_scan)
+
+    blocks = [
+        {0: [0.1, 0.2]},
+        {0: [0.3, 0.4]},
+    ]
+
+    def fake_read_block(board, ch_mask, block_samples, channel_indices, sample_rate_hz=None):
+        if blocks:
+            return blocks.pop(0)
+        return {ch: [] for ch in channel_indices}
+
+    monkeypatch.setattr("acquisition.read_block", fake_read_block)
+
+    sink_calls: list[str] = []
+
+    def sink_factory(_storage):
+        sink_calls.append("called")
+        return []
+
+    runner = AcquisitionRunner(
+        station=station,
+        storage=storage,
+        sink_factory=sink_factory,
+    )
+
+    runner.run(mode="test", test_channel=queue)
+
+    assert sink_calls == []
+    assert runner._test_blocks_broadcast == 2
+    assert runner._test_samples_broadcast == 4
+
+    first_block = queue.get_nowait()
+    assert isinstance(first_block, CalibratedBlock)
+    assert first_block.channels[0].values == [1.2, 1.4]
+
+    second_block = queue.get_nowait()
+    assert isinstance(second_block, CalibratedBlock)
+    assert second_block.channels[0].values == [1.6, 1.8]
+
+    sentinel = queue.get_nowait()
+    assert sentinel is None
+    with pytest.raises(asyncio.QueueEmpty):
+        queue.get_nowait()
+
+
+async def _collect_preview(
+    queue: "asyncio.Queue[CalibratedBlock | None]",
+    station: StationConfig,
+    options: PreviewOptions,
+):
+    payloads = []
+    async for payload in stream_preview(queue, station, options=options):
+        payloads.append(payload)
+    return payloads
+
+
+def test_stream_preview_downsamples_and_limits_duration():
+    acquisition = AcquisitionSettings(sample_rate_hz=10.0, block_size=4)
+    channels = [
+        ChannelConfig(
+            index=0,
+            name="A",
+            unit="mm",
+            voltage_range=10.0,
+            calibration=Calibration(gain=1.0, offset=0.0),
+        ),
+        ChannelConfig(
+            index=1,
+            name="B",
+            unit="mm",
+            voltage_range=10.0,
+            calibration=Calibration(gain=1.0, offset=0.0),
+        ),
+    ]
+    station = StationConfig(station_id="station", acquisition=acquisition, channels=channels)
+
+    block = CalibratedBlock(
+        station_id="station",
+        timestamps_ns=[0, 1_000_000_000, 2_000_000_000, 3_000_000_000],
+        channels={
+            0: CalibratedChannelBlock(index=0, name="A", unit="mm", values=[0.0, 0.1, 0.2, 0.3]),
+            1: CalibratedChannelBlock(index=1, name="B", unit="mm", values=[1.0, 1.1, 1.2, 1.3]),
+        },
+        captured_at_ns=123,
+    )
+
+    options = PreviewOptions(channels=[1], downsample=2, max_duration_s=2.0)
+
+    async def _run_preview():
+        queue: "asyncio.Queue[CalibratedBlock | None]" = asyncio.Queue()
+        await queue.put(block)
+        await queue.put(None)
+        return await _collect_preview(queue, station, options)
+
+    payloads = asyncio.run(_run_preview())
+
+    assert len(payloads) == 1
+    preview = payloads[0]
+    assert preview["timestamps_ns"] == [0, 2_000_000_000]
+    assert preview["channels"] == [
+        {
+            "index": 1,
+            "name": "B",
+            "unit": "mm",
+            "values": [1.0, 1.2],
+        }
+    ]


### PR DESCRIPTION
## Summary
- add calibrated block broadcasting support to `AcquisitionRunner` test mode, including logging and queue publication helpers
- introduce `edge/scr/preview.py` async utilities to stream downsampled preview data with configurable filters
- document test-mode limitations and add coverage for broadcast and preview logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d09302a52c8331987671d73cfac8c0