### PR TITLE
Add FastAPI web API with acquisition control and preview streaming

### DIFF
--- a/edge/service/webapi.service
+++ b/edge/service/webapi.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Edge MCC128 Web API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=JJSI
+WorkingDirectory=/home/JJSI/projects/raspi-mcc128-influx/edge
+EnvironmentFile=-/home/JJSI/projects/raspi-mcc128-influx/edge/.env
+ExecStart=/home/JJSI/venv-daq/bin/python -m edge.webapi.main
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/edge/webapi/__init__.py
+++ b/edge/webapi/__init__.py
@@ -1,0 +1,19 @@
+"""FastAPI application exposing configuration and acquisition endpoints."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .acquisition import router as acquisition_router
+from .configuration import router as config_router
+from .preview import router as preview_router
+
+app = FastAPI(title="MCC128 Edge Web API", version="1.0.0")
+
+app.include_router(config_router)
+app.include_router(acquisition_router)
+app.include_router(preview_router)
+
+
+__all__ = ["app"]
+

--- a/edge/webapi/acquisition.py
+++ b/edge/webapi/acquisition.py
@@ -1,0 +1,348 @@
+"""Acquisition session management endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import logging
+from threading import Event, Lock, Thread
+from typing import Callable, Dict, Literal
+
+import anyio
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from edge.config import (
+    StationConfig,
+    StorageSettings,
+    load_station_config,
+    load_storage_settings,
+)
+from edge.scr.acquisition import AcquisitionRunner, PreviewMessage
+
+from .auth import require_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/acquisition", tags=["acquisition"])
+
+ModeLiteral = Literal["continuous", "timed"]
+
+
+class StartSessionRequest(BaseModel):
+    """Payload used to start an acquisition session."""
+
+    mode: ModeLiteral = Field(
+        "continuous", description="Tipo de sesión: continua o temporizada"
+    )
+    preview: bool = Field(
+        True,
+        description="Si es True se ejecuta en modo test para exponer vista previa",
+    )
+
+
+class SessionSummary(BaseModel):
+    """Metadata describing a session lifecycle."""
+
+    mode: ModeLiteral
+    preview: bool
+    status: str
+    started_at: datetime
+    finished_at: datetime | None = None
+    station_id: str
+    error: str | None = None
+
+
+class StopResponse(BaseModel):
+    message: str
+    session: SessionSummary
+
+
+class PreviewQueue:
+    """Thread-safe bridge between the runner and async consumers."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, *, maxsize: int = 4) -> None:
+        self._loop = loop
+        self._queue: asyncio.Queue[PreviewMessage] = asyncio.Queue(maxsize)
+        self._closed = False
+
+    def _enqueue(self, item: PreviewMessage, *, force: bool = False) -> None:
+        if self._closed and not force:
+            return
+
+        def _put() -> None:
+            if self._closed and not force:
+                return
+            if self._queue.full():
+                try:
+                    dropped = self._queue.get_nowait()
+                    self._queue.task_done()
+                    if dropped is not None:
+                        logger.warning(
+                            "Cola de vista previa llena; se descarta un bloque antiguo."
+                        )
+                except asyncio.QueueEmpty:  # pragma: no cover - carrera improbable
+                    pass
+            self._queue.put_nowait(item)
+
+        self._loop.call_soon_threadsafe(_put)
+
+    def put_nowait(self, item: PreviewMessage) -> None:
+        self._enqueue(item)
+
+    async def get(self) -> PreviewMessage:
+        return await self._queue.get()
+
+    def task_done(self) -> None:
+        self._queue.task_done()
+
+    def qsize(self) -> int:
+        return self._queue.qsize()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._enqueue(None, force=True)
+
+
+@dataclass
+class AcquisitionSession:
+    """Track a running acquisition session in a background thread."""
+
+    runner: AcquisitionRunner
+    station: StationConfig
+    storage: StorageSettings
+    mode: ModeLiteral
+    preview_enabled: bool
+    loop: asyncio.AbstractEventLoop
+
+    def __post_init__(self) -> None:
+        self.preview_queue: PreviewQueue | None = (
+            PreviewQueue(self.loop) if self.preview_enabled else None
+        )
+        self._thread: Thread | None = None
+        self._stop_event = Event()
+        self._status = "starting"
+        self._error: str | None = None
+        self._preview_consumers = 0
+        self._preview_lock = Lock()
+        self.started_at = datetime.now(timezone.utc)
+        self.finished_at: datetime | None = None
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        queue = self.preview_queue if self.preview_enabled else None
+        requested_mode = self.mode
+        actual_mode = "test" if self.preview_enabled else requested_mode
+
+        def _runner() -> None:
+            nonlocal actual_mode
+            logger.info(
+                "Iniciando sesión de adquisición (mode=%s preview=%s)",
+                requested_mode,
+                self.preview_enabled,
+            )
+            self._status = "running"
+            try:
+                self.runner.run(mode=actual_mode, test_channel=queue)
+                if self._status == "running":
+                    self._status = "finished"
+            except Exception as exc:  # pragma: no cover - requiere hardware real
+                self._status = "failed"
+                self._error = str(exc)
+                logger.exception("La sesión de adquisición falló")
+            finally:
+                self.finished_at = datetime.now(timezone.utc)
+                if self.preview_queue is not None:
+                    self.preview_queue.close()
+                self._stop_event.set()
+                logger.info("Sesión de adquisición finalizada (status=%s)", self._status)
+
+        self._thread = Thread(target=_runner, daemon=True)
+        self._thread.start()
+
+    # ------------------------------------------------------------------
+    def stop(self, timeout: float = 10.0) -> None:
+        if self.preview_queue is not None:
+            self.preview_queue.close()
+        try:
+            self.runner.request_stop()
+        except Exception:  # pragma: no cover - defensivo
+            logger.exception("Error solicitando stop al runner")
+        if not self._stop_event.wait(timeout):
+            logger.warning("Timeout esperando cierre de la sesión de adquisición")
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=timeout)
+        if self.finished_at is None:
+            self.finished_at = datetime.now(timezone.utc)
+        if self._status == "running":
+            self._status = "stopped"
+
+    # ------------------------------------------------------------------
+    @property
+    def is_active(self) -> bool:
+        if self._stop_event.is_set():
+            return False
+        thread = self._thread
+        if thread and not thread.is_alive():
+            self._stop_event.set()
+            return False
+        return True
+
+    def info(self) -> Dict[str, object]:
+        return {
+            "mode": self.mode,
+            "preview": self.preview_enabled,
+            "status": self._status,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "station_id": self.station.station_id,
+            "error": self._error,
+        }
+
+    def acquire_preview_queue(self) -> PreviewQueue:
+        if not self.preview_enabled or self.preview_queue is None:
+            raise RuntimeError("La sesión actual no expone vista previa")
+        with self._preview_lock:
+            if self._preview_consumers >= 1:
+                raise RuntimeError("Ya existe un cliente consumiendo la vista previa")
+            self._preview_consumers += 1
+        return self.preview_queue
+
+    def release_preview_queue(self) -> None:
+        with self._preview_lock:
+            if self._preview_consumers > 0:
+                self._preview_consumers -= 1
+
+
+RunnerFactory = Callable[[StationConfig, StorageSettings], AcquisitionRunner]
+
+
+class AcquisitionSessionManager:
+    """Coordinate session lifecycle and prevent concurrent runs."""
+
+    def __init__(self, *, runner_factory: RunnerFactory | None = None) -> None:
+        self._runner_factory = runner_factory or (
+            lambda station, storage: AcquisitionRunner(station=station, storage=storage)
+        )
+        self._lock = asyncio.Lock()
+        self._session: AcquisitionSession | None = None
+        self._last_summary: Dict[str, object] | None = None
+
+    async def _cleanup_finished_session_locked(self) -> None:
+        session = self._session
+        if session and not session.is_active:
+            self._last_summary = session.info()
+            self._session = None
+
+    async def start_session(self, request: StartSessionRequest) -> Dict[str, object]:
+        async with self._lock:
+            await self._cleanup_finished_session_locked()
+            if self._session is not None:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Ya existe una sesión en ejecución",
+                )
+            station = await anyio.to_thread.run_sync(load_station_config)
+            storage = await anyio.to_thread.run_sync(load_storage_settings)
+            runner = self._runner_factory(station, storage)
+            loop = asyncio.get_running_loop()
+            session = AcquisitionSession(
+                runner=runner,
+                station=station,
+                storage=storage,
+                mode=request.mode,
+                preview_enabled=request.preview,
+                loop=loop,
+            )
+            session.start()
+            self._session = session
+            self._last_summary = None
+            return session.info()
+
+    async def stop_session(self) -> Dict[str, object]:
+        async with self._lock:
+            await self._cleanup_finished_session_locked()
+            session = self._session
+            if session is None:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="No hay sesiones activas",
+                )
+            await anyio.to_thread.run_sync(session.stop)
+            summary = session.info()
+            self._last_summary = summary
+            self._session = None
+            return summary
+
+    async def current_session(self) -> Dict[str, object] | None:
+        async with self._lock:
+            await self._cleanup_finished_session_locked()
+            session = self._session
+            if session is None:
+                return None
+            return session.info()
+
+    async def last_session(self) -> Dict[str, object] | None:
+        async with self._lock:
+            await self._cleanup_finished_session_locked()
+            if self._session is not None:
+                return None
+            return self._last_summary
+
+    async def acquire_preview(self) -> tuple[AcquisitionSession, PreviewQueue]:
+        async with self._lock:
+            await self._cleanup_finished_session_locked()
+            session = self._session
+            if session is None or not session.preview_enabled:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="No hay sesión con vista previa disponible",
+                )
+            queue = session.acquire_preview_queue()
+            return session, queue
+
+    async def release_preview(self, session: AcquisitionSession) -> None:
+        async with self._lock:
+            current = self._session
+            if current is session:
+                session.release_preview_queue()
+            else:
+                # La sesión finalizó pero se libera el contador igualmente.
+                session.release_preview_queue()
+
+
+session_manager = AcquisitionSessionManager()
+
+
+@router.post("/start", response_model=SessionSummary, status_code=status.HTTP_202_ACCEPTED)
+async def start_acquisition(
+    request: StartSessionRequest,
+    _: None = Depends(require_token),
+) -> Dict[str, object]:
+    """Start a new acquisition session."""
+
+    info = await session_manager.start_session(request)
+    return info
+
+
+@router.post("/stop", response_model=StopResponse)
+async def stop_acquisition(_: None = Depends(require_token)) -> Dict[str, object]:
+    """Stop the active session if present."""
+
+    summary = await session_manager.stop_session()
+    return {"message": "Sesión detenida", "session": summary}
+
+
+@router.get("/session", response_model=Dict[str, object])
+async def session_status(_: None = Depends(require_token)) -> Dict[str, object]:
+    """Return the active session metadata or the last finished session."""
+
+    current = await session_manager.current_session()
+    if current is not None:
+        return {"active": True, "session": current}
+    last = await session_manager.last_session()
+    return {"active": False, "last_session": last}
+

--- a/edge/webapi/auth.py
+++ b/edge/webapi/auth.py
@@ -1,0 +1,63 @@
+"""Authentication helpers for the web API."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Optional
+
+from fastapi import HTTPException, Security, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+@lru_cache(maxsize=1)
+def _token_from_file(path: str) -> Optional[str]:
+    """Return the contents of ``path`` if it exists, otherwise ``None``."""
+
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            token = fh.read().strip()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:  # pragma: no cover - defensive best effort
+        raise RuntimeError(f"No se pudo leer el token desde {path}: {exc}") from exc
+    return token or None
+
+
+def _expected_token() -> Optional[str]:
+    """Lookup the configured bearer token."""
+
+    token = os.environ.get("EDGE_WEBAPI_TOKEN")
+    if token:
+        return token.strip() or None
+    token_file = os.environ.get("EDGE_WEBAPI_TOKEN_FILE")
+    if token_file:
+        return _token_from_file(token_file)
+    return None
+
+
+async def require_token(
+    credentials: HTTPAuthorizationCredentials | None = Security(_bearer_scheme),
+) -> None:
+    """Validate the Bearer token when authentication is enabled."""
+
+    expected = _expected_token()
+    if not expected:
+        # Authentication disabled -> accept every request.
+        return
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token requerido",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    if credentials.scheme.lower() != "bearer" or credentials.credentials != expected:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token inválido",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+

--- a/edge/webapi/configuration.py
+++ b/edge/webapi/configuration.py
@@ -1,0 +1,148 @@
+"""Configuration endpoints exposing typed schemas."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Mapping
+
+import anyio
+from fastapi import APIRouter, Body, Depends, HTTPException, status
+
+from edge.config import (
+    StationConfig,
+    StorageSettings,
+    load_station_config,
+    load_storage_settings,
+    save_station_config,
+    save_storage_settings,
+)
+
+from .auth import require_token
+
+router = APIRouter(prefix="/config", tags=["config"])
+
+_station_lock = asyncio.Lock()
+_storage_lock = asyncio.Lock()
+
+
+def _serialize_station(config: StationConfig) -> Dict[str, Any]:
+    payload = config.to_dict()
+    if config.description:
+        payload["description"] = config.description
+    return payload
+
+
+def _serialize_storage(settings: StorageSettings) -> Dict[str, Any]:
+    return settings.to_dict()
+
+
+def _serialize_influx(settings: StorageSettings) -> Dict[str, Any]:
+    payload = {
+        "driver": settings.driver,
+        "url": settings.url,
+        "org": settings.org,
+        "bucket": settings.bucket,
+        "token": settings.token,
+        "timeout_s": settings.timeout_s,
+        "verify_ssl": settings.verify_ssl,
+    }
+    return payload
+
+
+async def _load_station() -> StationConfig:
+    return await anyio.to_thread.run_sync(load_station_config)
+
+
+async def _load_storage() -> StorageSettings:
+    return await anyio.to_thread.run_sync(load_storage_settings)
+
+
+@router.get("/mcc128")
+async def get_station_config(_: None = Depends(require_token)) -> Dict[str, Any]:
+    """Return the current MCC128 configuration."""
+
+    config = await _load_station()
+    return _serialize_station(config)
+
+
+@router.put("/mcc128")
+async def update_station_config(
+    payload: Mapping[str, Any] = Body(..., description="Payload completo de sensors.yaml"),
+    _: None = Depends(require_token),
+) -> Dict[str, Any]:
+    """Persist a new station configuration after validation."""
+
+    try:
+        candidate = StationConfig.from_mapping(dict(payload))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+
+    async with _station_lock:
+        await anyio.to_thread.run_sync(save_station_config, candidate)
+    return _serialize_station(candidate)
+
+
+@router.get("/storage")
+async def get_storage_settings(_: None = Depends(require_token)) -> Dict[str, Any]:
+    settings = await _load_storage()
+    return _serialize_storage(settings)
+
+
+@router.put("/storage")
+async def update_storage_settings(
+    payload: Mapping[str, Any] = Body(..., description="Payload completo de storage.yaml"),
+    _: None = Depends(require_token),
+) -> Dict[str, Any]:
+    try:
+        candidate = StorageSettings.from_mapping(dict(payload))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+
+    async with _storage_lock:
+        await anyio.to_thread.run_sync(save_storage_settings, candidate)
+    return _serialize_storage(candidate)
+
+
+_ALLOWED_INFLUX_FIELDS = {
+    "driver",
+    "url",
+    "org",
+    "bucket",
+    "token",
+    "timeout_s",
+    "verify_ssl",
+}
+
+
+@router.get("/influx")
+async def get_influx_credentials(_: None = Depends(require_token)) -> Dict[str, Any]:
+    settings = await _load_storage()
+    return _serialize_influx(settings)
+
+
+@router.put("/influx")
+async def update_influx_credentials(
+    payload: Mapping[str, Any] = Body(..., description="Campos parciales para credenciales de Influx"),
+    _: None = Depends(require_token),
+) -> Dict[str, Any]:
+    unknown = set(payload.keys()) - _ALLOWED_INFLUX_FIELDS
+    if unknown:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Campos no soportados: {', '.join(sorted(unknown))}",
+        )
+
+    async with _storage_lock:
+        settings = await _load_storage()
+        base = settings.to_dict()
+        base.update({key: payload[key] for key in payload if key in _ALLOWED_INFLUX_FIELDS})
+        try:
+            candidate = StorageSettings.from_mapping(base)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(exc),
+            )
+        await anyio.to_thread.run_sync(save_storage_settings, candidate)
+        return _serialize_influx(candidate)
+

--- a/edge/webapi/main.py
+++ b/edge/webapi/main.py
@@ -1,0 +1,26 @@
+"""Uvicorn bootstrap for the MCC128 Web API."""
+
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+from . import app
+
+def main() -> None:
+    host = os.environ.get("EDGE_WEBAPI_HOST", "0.0.0.0")
+    port = int(os.environ.get("EDGE_WEBAPI_PORT", "8000"))
+    reload_flag = os.environ.get("EDGE_WEBAPI_RELOAD", "0")
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        reload=reload_flag.lower() in {"1", "true", "yes"},
+        log_level=os.environ.get("EDGE_WEBAPI_LOG_LEVEL", "info"),
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/edge/webapi/preview.py
+++ b/edge/webapi/preview.py
@@ -1,0 +1,68 @@
+"""Preview streaming endpoints."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import StreamingResponse
+
+from edge.scr.preview import PreviewOptions, stream_preview
+
+from .acquisition import session_manager
+from .auth import require_token
+
+router = APIRouter(prefix="/preview", tags=["preview"])
+
+
+def _parse_channels(raw: Optional[Iterable[int]]) -> Optional[List[int]]:
+    if raw is None:
+        return None
+    return [int(ch) for ch in raw]
+
+
+@router.get("/stream")
+async def preview_stream(
+    request: Request,
+    channels: Optional[List[int]] = Query(None, description="Lista de índices de canal"),
+    max_duration_s: Optional[float] = Query(
+        None, description="Cortar el stream tras esta cantidad de segundos"
+    ),
+    downsample: int = Query(1, ge=1, description="Tomar una muestra cada N"),
+    _: None = Depends(require_token),
+):
+    """Yield preview samples using Server-Sent Events."""
+
+    try:
+        session, queue = await session_manager.acquire_preview()
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        ) from exc
+
+    options = PreviewOptions(
+        channels=_parse_channels(channels),
+        max_duration_s=max_duration_s,
+        downsample=downsample,
+    )
+
+    async def event_source():
+        try:
+            async for payload in stream_preview(queue, session.station, options=options):
+                if await request.is_disconnected():
+                    break
+                data = json.dumps(payload, ensure_ascii=False)
+                yield f"data: {data}\n\n"
+        finally:
+            await session_manager.release_preview(session)
+
+    headers = {
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+    }
+    return StreamingResponse(event_source(), media_type="text/event-stream", headers=headers)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ requests
 python-dotenv
 pyyaml
 responses
+fastapi
+uvicorn

--- a/tests/test_webapi.py
+++ b/tests/test_webapi.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+import shutil
+
+import pytest
+from fastapi.testclient import TestClient
+
+from edge.config import store as config_store
+from edge.scr.acquisition import CalibratedBlock, CalibratedChannelBlock
+from edge.webapi import app
+from edge.webapi import acquisition as acquisition_module
+from edge.webapi import preview as preview_module
+from edge.webapi.acquisition import AcquisitionSessionManager
+
+
+@pytest.fixture(autouse=True)
+def clear_auth_env(monkeypatch):
+    monkeypatch.delenv("EDGE_WEBAPI_TOKEN", raising=False)
+    monkeypatch.delenv("EDGE_WEBAPI_TOKEN_FILE", raising=False)
+
+
+@pytest.fixture
+def temp_config_dir(tmp_path, monkeypatch):
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    source_dir = Path("edge/config")
+    for name in ("sensors.yaml", "storage.yaml"):
+        shutil.copy(source_dir / name, cfg_dir / name)
+    monkeypatch.setattr(config_store, "CONFIG_DIR", cfg_dir)
+    return cfg_dir
+
+
+@pytest.fixture
+def api_client(temp_config_dir):
+    return TestClient(app)
+
+
+class FakeRunner:
+    def __init__(self, station, storage):
+        self.station = station
+        self.storage = storage
+        self.mode = None
+        self.stop_event = threading.Event()
+
+    def request_stop(self):
+        self.stop_event.set()
+
+    def run(self, mode="continuous", test_channel=None):
+        self.mode = mode
+        if test_channel is not None:
+            first_channel = next(iter(self.station.channels))
+            block = CalibratedBlock(
+                station_id=self.station.station_id,
+                timestamps_ns=[1_000_000_000, 1_000_500_000],
+                channels={
+                    first_channel.index: CalibratedChannelBlock(
+                        index=first_channel.index,
+                        name=first_channel.name,
+                        unit=first_channel.unit,
+                        values=[0.1, 0.2],
+                    )
+                },
+                captured_at_ns=1_001_000_000,
+            )
+            test_channel.put_nowait(block)
+        self.stop_event.wait(0.2)
+        if test_channel is not None:
+            test_channel.put_nowait(None)
+
+
+@pytest.fixture
+def stubbed_session_manager(monkeypatch):
+    manager = AcquisitionSessionManager(
+        runner_factory=lambda station, storage: FakeRunner(station, storage)
+    )
+    monkeypatch.setattr(acquisition_module, "session_manager", manager)
+    monkeypatch.setattr(preview_module, "session_manager", manager)
+    yield manager
+    # restore clean manager for future tests
+    fresh = AcquisitionSessionManager()
+    acquisition_module.session_manager = fresh
+    preview_module.session_manager = fresh
+
+
+def test_get_station_config(api_client):
+    response = api_client.get("/config/mcc128")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["station_id"]
+    assert "channels" in payload
+
+
+def test_update_station_config_validation(api_client):
+    # Missing station_id should trigger validation error
+    invalid_payload = {"acquisition": {"sample_rate_hz": 10, "block_size": 10}, "channels": []}
+    response = api_client.put("/config/mcc128", json=invalid_payload)
+    assert response.status_code == 422
+
+
+def test_update_influx_partial(api_client):
+    response = api_client.put("/config/influx", json={"token": "new-token"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["token"] == "new-token"
+
+
+def test_acquisition_lifecycle_with_preview(api_client, stubbed_session_manager):
+    start = api_client.post("/acquisition/start", json={"mode": "continuous", "preview": True})
+    assert start.status_code == 202
+    body = start.json()
+    assert body["preview"] is True
+
+    # Consume preview stream (SSE)
+    with api_client.stream("GET", "/preview/stream") as response:
+        assert response.status_code == 200
+        chunks = [
+            chunk.decode() if isinstance(chunk, bytes) else chunk
+            for chunk in response.iter_lines()
+        ]
+    assert any(chunk.startswith("data: ") for chunk in chunks if chunk)
+
+    # Allow background thread to finish
+    time.sleep(0.1)
+    status_resp = api_client.get("/acquisition/session")
+    assert status_resp.status_code == 200
+    status_payload = status_resp.json()
+    assert status_payload["active"] in {False, True}
+
+    # Attempt to stop (idempotent even if already finished)
+    stop = api_client.post("/acquisition/stop")
+    if stop.status_code == 200:
+        summary = stop.json()["session"]
+        assert summary["mode"] == "continuous"
+    else:
+        assert stop.status_code == 409
+


### PR DESCRIPTION
## Summary
- add a FastAPI application under `edge/webapi` with routers for configuration, acquisition lifecycle and preview streaming
- implement token-based authentication, concurrency-safe config updates and SSE preview output backed by the acquisition session manager
- ship a uvicorn entry point, new systemd unit for the web API and dedicated integration tests exercising the endpoints

## Testing
- `pip install fastapi uvicorn` *(fails: proxy blocks access to package index)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68d095d287fc83319c14ee2e5bb7e0d8