### PR TITLE
Add MCC128 web UI with configuration and preview dashboards

### DIFF
--- a/edge/webui/.eslintrc.cjs
+++ b/edge/webui/.eslintrc.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true,
+  },
+  extends: ["eslint:recommended", "plugin:react/recommended", "plugin:react-hooks/recommended", "plugin:@typescript-eslint/recommended", "prettier"],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  plugins: ["react", "@typescript-eslint", "react-hooks"],
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
+  rules: {
+    "react/react-in-jsx-scope": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
+  },
+};

--- a/edge/webui/.gitignore
+++ b/edge/webui/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+.env.local
+.env.*

--- a/edge/webui/index.html
+++ b/edge/webui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MCC128 Edge Control</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/edge/webui/package.json
+++ b/edge/webui/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "mcc128-edge-webui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --host",
+    "check": "tsc --noEmit",
+    "lint": "eslint src --ext ts,tsx",
+    "deploy": "npm run build && bash scripts/deploy.sh"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.45.0",
+    "chart.js": "^4.4.4",
+    "react": "^18.3.1",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "@typescript-eslint/eslint-plugin": "^7.8.1",
+    "@typescript-eslint/parser": "^7.8.1",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/edge/webui/public/favicon.svg
+++ b/edge/webui/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#14b8a6" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="#0f172a" />
+  <path d="M32 88L52 40l12 20 12-20 20 48" stroke="url(#grad)" stroke-width="10" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/edge/webui/scripts/deploy.sh
+++ b/edge/webui/scripts/deploy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+DIST_DIR="$ROOT_DIR/dist"
+TARGET_DIR="${DEPLOY_WEBUI_TARGET:-/var/www/edge-webui}"
+SYSTEMD_SERVICE="${DEPLOY_SYSTEMD_SERVICE:-edge.service}"
+NGINX_SERVICE="${DEPLOY_NGINX_SERVICE:-nginx}"
+
+if [ ! -d "$DIST_DIR" ]; then
+  echo "⚠️ El directorio dist no existe. Ejecuta 'npm run build' primero." >&2
+  exit 1
+fi
+
+echo "→ Copiando artefactos a $TARGET_DIR"
+sudo mkdir -p "$TARGET_DIR"
+sudo rsync -a --delete "$DIST_DIR"/ "$TARGET_DIR"/
+
+echo "→ Recargando servicios"
+if [ -n "$SYSTEMD_SERVICE" ]; then
+  sudo systemctl reload "$SYSTEMD_SERVICE" 2>/dev/null || sudo systemctl restart "$SYSTEMD_SERVICE" || true
+fi
+if [ -n "$NGINX_SERVICE" ]; then
+  sudo systemctl reload "$NGINX_SERVICE" || true
+fi
+
+echo "✅ Despliegue completado"

--- a/edge/webui/src/App.tsx
+++ b/edge/webui/src/App.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiClient, ApiError, createApiClient } from "./api";
+import { ErrorBanner } from "./components/ErrorBanner";
+import { TokenManager } from "./components/TokenManager";
+import { PreviewDashboard } from "./pages/PreviewDashboard";
+import { ServiceStatusPanel } from "./pages/ServiceStatusPanel";
+import { StationConfigView } from "./pages/StationConfigView";
+import { StorageSettingsView } from "./pages/StorageSettingsView";
+import { StationConfig, StorageSettings } from "./types";
+
+const TOKEN_KEY = "edge-webui-token";
+
+const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+export default function App() {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem(TOKEN_KEY));
+  const [stationDraft, setStationDraft] = useState<StationConfig | null>(null);
+  const [storageDraft, setStorageDraft] = useState<StorageSettings | null>(null);
+  const [stationDirty, setStationDirty] = useState(false);
+  const [storageDirty, setStorageDirty] = useState(false);
+  const [stationSaving, setStationSaving] = useState(false);
+  const [storageSaving, setStorageSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const queryClient = useQueryClient();
+  const api: ApiClient | null = useMemo(() => {
+    if (!token) {
+      return null;
+    }
+    return createApiClient({ getToken: () => token });
+  }, [token]);
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem(TOKEN_KEY, token);
+    } else {
+      localStorage.removeItem(TOKEN_KEY);
+    }
+  }, [token]);
+
+  const stationQuery = useQuery({
+    queryKey: ["station-config"],
+    queryFn: () => api!.getStationConfig(),
+    enabled: Boolean(api),
+  });
+
+  const storageQuery = useQuery({
+    queryKey: ["storage-settings"],
+    queryFn: () => api!.getStorageSettings(),
+    enabled: Boolean(api),
+  });
+
+  const sessionQuery = useQuery({
+    queryKey: ["session-status"],
+    queryFn: () => api!.getSessionStatus(),
+    enabled: Boolean(api),
+    refetchInterval: 10000,
+  });
+
+  useEffect(() => {
+    if (stationQuery.data) {
+      setStationDraft(clone(stationQuery.data));
+      setStationDirty(false);
+    }
+  }, [stationQuery.data]);
+
+  useEffect(() => {
+    if (storageQuery.data) {
+      setStorageDraft(clone(storageQuery.data));
+      setStorageDirty(false);
+    }
+  }, [storageQuery.data]);
+
+  useEffect(() => {
+    if (sessionQuery.error instanceof ApiError && sessionQuery.error.status === 401) {
+      setErrorMessage("Token inválido. Actualiza las credenciales.");
+    }
+  }, [sessionQuery.error]);
+
+  useEffect(() => {
+    const error = stationQuery.error || storageQuery.error;
+    if (error instanceof ApiError) {
+      setErrorMessage(error.message);
+    } else if (error) {
+      setErrorMessage("Error comunicando con la API.");
+    }
+  }, [stationQuery.error, storageQuery.error]);
+
+  const handleStationChange = (next: StationConfig) => {
+    setStationDraft(next);
+    setStationDirty(true);
+  };
+
+  const handleStorageChange = (next: StorageSettings) => {
+    setStorageDraft(next);
+    setStorageDirty(true);
+  };
+
+  const handleStationSave = async () => {
+    if (!api || !stationDraft) return;
+    if (!confirm("¿Sobrescribir configuración de la MCC128?")) {
+      return;
+    }
+    setStationSaving(true);
+    try {
+      const updated = await api.updateStationConfig(stationDraft);
+      setStationDraft(clone(updated));
+      setStationDirty(false);
+      await queryClient.invalidateQueries({ queryKey: ["station-config"] });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("No se pudo guardar la configuración de la MCC128.");
+      }
+    } finally {
+      setStationSaving(false);
+    }
+  };
+
+  const handleStorageSave = async () => {
+    if (!api || !storageDraft) return;
+    if (!confirm("¿Actualizar la configuración de almacenamiento?")) {
+      return;
+    }
+    setStorageSaving(true);
+    try {
+      const updated = await api.updateStorageSettings(storageDraft);
+      setStorageDraft(clone(updated));
+      setStorageDirty(false);
+      await queryClient.invalidateQueries({ queryKey: ["storage-settings"] });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("No se pudo guardar la configuración de almacenamiento.");
+      }
+    } finally {
+      setStorageSaving(false);
+    }
+  };
+
+  const handleTokenUpdate = (next: string | null) => {
+    setToken(next);
+    setStationDraft(null);
+    setStorageDraft(null);
+    setStationDirty(false);
+    setStorageDirty(false);
+    setErrorMessage(null);
+    queryClient.clear();
+  };
+
+  const handleSessionRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: ["session-status"] }).catch(() => {
+      /* noop */
+    });
+  };
+
+  const previewReady = Boolean(sessionQuery.data?.active && sessionQuery.data.session?.preview);
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <h1>MCC128 Edge UI</h1>
+        <p className="muted">Gestiona la adquisición y almacenamiento desde la interfaz web.</p>
+      </header>
+
+      <TokenManager token={token} onUpdate={handleTokenUpdate} />
+      <ErrorBanner message={errorMessage} onClose={() => setErrorMessage(null)} />
+
+      {!api && <p>Introduce un token para conectar con el backend.</p>}
+
+      <main>
+        <StationConfigView
+          config={stationDraft}
+          onChange={handleStationChange}
+          onSubmit={handleStationSave}
+          onRefresh={() => stationQuery.refetch()}
+          dirty={stationDirty}
+          saving={stationSaving}
+          loading={stationQuery.isLoading || !api}
+        />
+
+        <StorageSettingsView
+          settings={storageDraft}
+          onChange={handleStorageChange}
+          onSubmit={handleStorageSave}
+          onRefresh={() => storageQuery.refetch()}
+          dirty={storageDirty}
+          saving={storageSaving}
+          loading={storageQuery.isLoading || !api}
+        />
+
+        <PreviewDashboard
+          api={api}
+          station={stationDraft}
+          sessionReady={previewReady}
+          onError={(message) => setErrorMessage(message)}
+        />
+
+        <ServiceStatusPanel
+          api={api}
+          status={sessionQuery.data ?? null}
+          loading={sessionQuery.isLoading || !api}
+          onRefresh={handleSessionRefresh}
+          onSessionChanged={handleSessionRefresh}
+          onError={(message) => setErrorMessage(message)}
+        />
+      </main>
+    </div>
+  );
+}

--- a/edge/webui/src/api.ts
+++ b/edge/webui/src/api.ts
@@ -1,0 +1,215 @@
+import {
+  PreviewMessagePayload,
+  PreviewStreamOptions,
+  SessionStatusResponse,
+  StartSessionRequest,
+  StationConfig,
+  StorageSettings,
+  StopResponse,
+} from "./types";
+
+export interface ApiClientOptions {
+  baseUrl?: string;
+  getToken?: () => string | null | undefined;
+}
+
+export class ApiError extends Error {
+  public readonly status: number;
+  public readonly details: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+const defaultBaseUrl = import.meta.env.VITE_API_BASE_URL || "";
+
+export class ApiClient {
+  private readonly baseUrl: string;
+  private readonly getToken: () => string | null | undefined;
+
+  constructor(options?: ApiClientOptions) {
+    this.baseUrl = options?.baseUrl?.replace(/\/$/, "") || defaultBaseUrl;
+    this.getToken = options?.getToken || (() => null);
+  }
+
+  private resolveUrl(path: string): string {
+    if (!path.startsWith("/")) {
+      path = `/${path}`;
+    }
+    if (!this.baseUrl) {
+      return path;
+    }
+    return `${this.baseUrl}${path}`;
+  }
+
+  private buildHeaders(additional?: HeadersInit, options?: { json?: boolean }): Headers {
+    const headers = new Headers(additional);
+    const includeJson = options?.json ?? true;
+    if (includeJson && !headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    const token = this.getToken();
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+    return headers;
+  }
+
+  private async handleResponse<T>(response: Response): Promise<T> {
+    if (response.ok) {
+      if (response.status === 204) {
+        return undefined as T;
+      }
+      const contentType = response.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        return (await response.json()) as T;
+      }
+      return (await response.text()) as unknown as T;
+    }
+
+    let details: unknown;
+    try {
+      const contentType = response.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        details = await response.json();
+      } else {
+        details = await response.text();
+      }
+    } catch (error) {
+      details = undefined;
+    }
+
+    const message =
+      typeof details === "object" && details !== null && "detail" in details
+        ? String((details as { detail: unknown }).detail)
+        : `Error ${response.status}`;
+    throw new ApiError(message, response.status, details);
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(this.resolveUrl(path), {
+      ...init,
+      headers: this.buildHeaders(init?.headers, {
+        json: init?.body !== undefined && init.body !== null,
+      }),
+    });
+    return this.handleResponse<T>(response);
+  }
+
+  async getStationConfig(): Promise<StationConfig> {
+    return this.request<StationConfig>("/config/mcc128");
+  }
+
+  async updateStationConfig(payload: StationConfig): Promise<StationConfig> {
+    return this.request<StationConfig>("/config/mcc128", {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async getStorageSettings(): Promise<StorageSettings> {
+    return this.request<StorageSettings>("/config/storage");
+  }
+
+  async updateStorageSettings(payload: StorageSettings): Promise<StorageSettings> {
+    return this.request<StorageSettings>("/config/storage", {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async getSessionStatus(): Promise<SessionStatusResponse> {
+    return this.request<SessionStatusResponse>("/acquisition/session");
+  }
+
+  async startAcquisition(payload: StartSessionRequest): Promise<SessionStatusResponse["session"]> {
+    return this.request("/acquisition/start", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async stopAcquisition(): Promise<StopResponse> {
+    return this.request<StopResponse>("/acquisition/stop", {
+      method: "POST",
+    });
+  }
+
+  openPreviewStream(
+    options: PreviewStreamOptions,
+    onMessage: (payload: PreviewMessagePayload) => void,
+    onError?: (error: unknown) => void,
+  ): () => void {
+    const controller = new AbortController();
+    const params = new URLSearchParams();
+    if (options.channels && options.channels.length > 0) {
+      for (const channel of options.channels) {
+        params.append("channels", String(channel));
+      }
+    }
+    if (options.max_duration_s) {
+      params.set("max_duration_s", String(options.max_duration_s));
+    }
+    if (options.downsample && options.downsample > 1) {
+      params.set("downsample", String(options.downsample));
+    }
+    const query = params.toString();
+    const url = `/preview/stream${query ? `?${query}` : ""}`;
+
+    const start = async () => {
+      try {
+        const response = await fetch(this.resolveUrl(url), {
+          method: "GET",
+          headers: this.buildHeaders({ Accept: "text/event-stream" }, { json: false }),
+          signal: controller.signal,
+        });
+        if (!response.ok || !response.body) {
+          throw new ApiError(`No se pudo abrir la vista previa (${response.status})`, response.status);
+        }
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder("utf-8");
+        let buffer = "";
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) {
+            break;
+          }
+          buffer += decoder.decode(value, { stream: true });
+          let boundary = buffer.indexOf("\n\n");
+          while (boundary !== -1) {
+            const rawEvent = buffer.slice(0, boundary);
+            buffer = buffer.slice(boundary + 2);
+            boundary = buffer.indexOf("\n\n");
+            const lines = rawEvent.split(/\n+/).map((line) => line.trim());
+            const dataLines = lines
+              .filter((line) => line.startsWith("data:"))
+              .map((line) => line.replace(/^data:\s*/, ""));
+            if (dataLines.length === 0) {
+              continue;
+            }
+            const payloadRaw = dataLines.join("\n");
+            try {
+              const payload = JSON.parse(payloadRaw) as PreviewMessagePayload;
+              onMessage(payload);
+            } catch (error) {
+              console.error("No se pudo parsear el evento SSE", error);
+            }
+          }
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          onError?.(error);
+        }
+      }
+    };
+
+    start();
+    return () => controller.abort();
+  }
+}
+
+export const createApiClient = (options?: ApiClientOptions): ApiClient => new ApiClient(options);

--- a/edge/webui/src/components/CalibrationInput.tsx
+++ b/edge/webui/src/components/CalibrationInput.tsx
@@ -1,0 +1,46 @@
+import { ChangeEvent } from "react";
+import { Calibration } from "../types";
+
+interface CalibrationInputProps {
+  value: Calibration;
+  onChange: (value: Calibration) => void;
+  disabled?: boolean;
+}
+
+export function CalibrationInput({ value, onChange, disabled }: CalibrationInputProps) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, value: raw } = event.target;
+    const numeric = Number.parseFloat(raw);
+    onChange({
+      ...value,
+      [name]: Number.isFinite(numeric) ? numeric : 0,
+    });
+  };
+
+  return (
+    <div className="calibration-input">
+      <label className="field">
+        <span>Ganancia</span>
+        <input
+          type="number"
+          name="gain"
+          step="0.0001"
+          value={value.gain}
+          onChange={handleChange}
+          disabled={disabled}
+        />
+      </label>
+      <label className="field">
+        <span>Offset</span>
+        <input
+          type="number"
+          name="offset"
+          step="0.0001"
+          value={value.offset}
+          onChange={handleChange}
+          disabled={disabled}
+        />
+      </label>
+    </div>
+  );
+}

--- a/edge/webui/src/components/ErrorBanner.tsx
+++ b/edge/webui/src/components/ErrorBanner.tsx
@@ -1,0 +1,21 @@
+interface ErrorBannerProps {
+  message: string | null;
+  onClose?: () => void;
+}
+
+export function ErrorBanner({ message, onClose }: ErrorBannerProps) {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <div className="error-banner" role="alert">
+      <span>{message}</span>
+      {onClose && (
+        <button type="button" onClick={onClose} aria-label="Cerrar">
+          ×
+        </button>
+      )}
+    </div>
+  );
+}

--- a/edge/webui/src/components/LoadingIndicator.tsx
+++ b/edge/webui/src/components/LoadingIndicator.tsx
@@ -1,0 +1,3 @@
+export function LoadingIndicator() {
+  return <div className="loading">Cargando…</div>;
+}

--- a/edge/webui/src/components/SectionCard.tsx
+++ b/edge/webui/src/components/SectionCard.tsx
@@ -1,0 +1,23 @@
+import { PropsWithChildren } from "react";
+
+interface SectionCardProps extends PropsWithChildren {
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+  id?: string;
+}
+
+export function SectionCard({ title, description, actions, id, children }: SectionCardProps) {
+  return (
+    <section className="section-card" id={id}>
+      <header>
+        <div>
+          <h2>{title}</h2>
+          {description && <p className="muted">{description}</p>}
+        </div>
+        {actions && <div className="actions">{actions}</div>}
+      </header>
+      <div className="section-body">{children}</div>
+    </section>
+  );
+}

--- a/edge/webui/src/components/SinkToggle.tsx
+++ b/edge/webui/src/components/SinkToggle.tsx
@@ -1,0 +1,21 @@
+interface SinkToggleProps {
+  sink: string;
+  label: string;
+  enabled: boolean;
+  onToggle: (sink: string, enabled: boolean) => void;
+  disabled?: boolean;
+}
+
+export function SinkToggle({ sink, label, enabled, onToggle, disabled }: SinkToggleProps) {
+  return (
+    <label className="sink-toggle">
+      <input
+        type="checkbox"
+        checked={enabled}
+        onChange={(event) => onToggle(sink, event.target.checked)}
+        disabled={disabled}
+      />
+      <span>{label}</span>
+    </label>
+  );
+}

--- a/edge/webui/src/components/TokenManager.tsx
+++ b/edge/webui/src/components/TokenManager.tsx
@@ -1,0 +1,48 @@
+import { FormEvent, useEffect, useState } from "react";
+
+interface TokenManagerProps {
+  token: string | null;
+  onUpdate: (token: string | null) => void;
+}
+
+export function TokenManager({ token, onUpdate }: TokenManagerProps) {
+  const [value, setValue] = useState(token ?? "");
+
+  useEffect(() => {
+    setValue(token ?? "");
+  }, [token]);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    onUpdate(value.trim() ? value.trim() : null);
+  };
+
+  const handleClear = () => {
+    if (confirm("¿Eliminar token guardado?")) {
+      setValue("");
+      onUpdate(null);
+    }
+  };
+
+  return (
+    <form className="token-manager" onSubmit={handleSubmit}>
+      <label>
+        <span>Token de acceso</span>
+        <input
+          type="password"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder="Bearer token"
+        />
+      </label>
+      <div className="actions">
+        <button type="submit">Guardar</button>
+        {token && (
+          <button type="button" className="secondary" onClick={handleClear}>
+            Limpiar
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/edge/webui/src/components/VoltageRangeSelect.tsx
+++ b/edge/webui/src/components/VoltageRangeSelect.tsx
@@ -1,0 +1,42 @@
+interface VoltageRangeSelectProps {
+  value: number;
+  onChange: (value: number) => void;
+  options?: number[];
+  disabled?: boolean;
+}
+
+const DEFAULT_VOLTAGE_RANGES = [10, 5, 2.5, 1, 0.5, 0.25, 0.1];
+
+export function VoltageRangeSelect({ value, onChange, options, disabled }: VoltageRangeSelectProps) {
+  const handleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    onChange(Number.parseFloat(event.target.value));
+  };
+
+  const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const parsed = Number.parseFloat(event.target.value);
+    if (Number.isFinite(parsed)) {
+      onChange(parsed);
+    }
+  };
+
+  const ranges = options?.length ? options : DEFAULT_VOLTAGE_RANGES;
+
+  return (
+    <div className="voltage-select">
+      <select value={value} onChange={handleSelect} disabled={disabled}>
+        {ranges.map((range) => (
+          <option key={range} value={range}>
+            ±{range} V
+          </option>
+        ))}
+      </select>
+      <input
+        type="number"
+        step="0.1"
+        value={value}
+        onChange={handleInput}
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/edge/webui/src/env.d.ts
+++ b/edge/webui/src/env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+  readonly VITE_PUBLIC_PATH?: string;
+  readonly VITE_DEV_PORT?: string;
+  readonly VITE_API_PROXY?: string;
+  readonly VITE_API_TARGET?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/edge/webui/src/main.tsx
+++ b/edge/webui/src/main.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App";
+import "./styles/index.css";
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/edge/webui/src/pages/PreviewDashboard.tsx
+++ b/edge/webui/src/pages/PreviewDashboard.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+import { SectionCard } from "../components/SectionCard";
+import { ApiClient } from "../api";
+import { PreviewMessagePayload, StationConfig } from "../types";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+interface PreviewDashboardProps {
+  api: ApiClient | null;
+  station: StationConfig | null;
+  sessionReady: boolean;
+  onError: (message: string) => void;
+}
+
+interface DatasetState {
+  label: string;
+  data: number[];
+  borderColor: string;
+  tension: number;
+}
+
+interface ChartState {
+  labels: number[];
+  datasets: Record<number, DatasetState>;
+}
+
+const MAX_POINTS = 500;
+const COLORS = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"];
+
+export function PreviewDashboard({ api, station, sessionReady, onError }: PreviewDashboardProps) {
+  const [selectedChannels, setSelectedChannels] = useState<number[]>([]);
+  const [downsample, setDownsample] = useState(1);
+  const [streaming, setStreaming] = useState(false);
+  const [chartState, setChartState] = useState<ChartState>({ labels: [], datasets: {} });
+  const abortRef = useRef<(() => void) | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!station) {
+      setSelectedChannels([]);
+      return;
+    }
+    setSelectedChannels((prev) => {
+      const available = new Set(station.channels.map((channel) => channel.index));
+      const filtered = prev.filter((index) => available.has(index));
+      if (filtered.length === 0) {
+        return station.channels.map((channel) => channel.index);
+      }
+      if (filtered.length !== prev.length) {
+        return filtered;
+      }
+      return prev;
+    });
+  }, [station]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!sessionReady && streaming) {
+      stopStream();
+    }
+  }, [sessionReady, streaming]);
+
+  const handleMessage = (payload: PreviewMessagePayload) => {
+    if (startTimeRef.current === null) {
+      startTimeRef.current = payload.timestamps_ns[0];
+    }
+    const origin = startTimeRef.current ?? payload.timestamps_ns[0];
+    const labels = payload.timestamps_ns.map((ts) => (ts - origin) / 1e9);
+    setChartState((prev) => {
+      const nextLabels = [...prev.labels, ...labels];
+      const datasets: Record<number, DatasetState> = { ...prev.datasets };
+      payload.channels.forEach((channel) => {
+        const color = COLORS[channel.index % COLORS.length];
+        const previous = prev.datasets[channel.index];
+        const base: DatasetState = previous
+          ? { ...previous, data: [...previous.data] }
+          : {
+              label: `${channel.name} (${channel.unit})`,
+              data: [],
+              borderColor: color,
+              tension: 0.1,
+            };
+        base.data.push(...channel.values);
+        datasets[channel.index] = base;
+      });
+      const trimmedLabels = nextLabels.slice(-MAX_POINTS);
+      const trimLength = trimmedLabels.length;
+      Object.entries(datasets).forEach(([key, dataset]) => {
+        dataset.data = dataset.data.slice(-trimLength);
+        datasets[Number(key)] = { ...dataset };
+      });
+      return { labels: trimmedLabels, datasets };
+    });
+  };
+
+  const handleError = (error: unknown) => {
+    console.error("Error en stream de vista previa", error);
+    onError(
+      error instanceof Error
+        ? error.message
+        : "La vista previa se interrumpió. Revisa el estado del servicio.",
+    );
+    stopStream();
+  };
+
+  const startStream = () => {
+    if (!api || !sessionReady) {
+      onError("No hay sesión de vista previa disponible.");
+      return;
+    }
+    setChartState({ labels: [], datasets: {} });
+    startTimeRef.current = null;
+    abortRef.current?.();
+    abortRef.current = api.openPreviewStream(
+      { channels: selectedChannels, downsample },
+      handleMessage,
+      handleError,
+    );
+    setStreaming(true);
+  };
+
+  const stopStream = () => {
+    abortRef.current?.();
+    abortRef.current = null;
+    setStreaming(false);
+  };
+
+  const toggleChannel = (channelIndex: number) => {
+    setSelectedChannels((prev) => {
+      if (prev.includes(channelIndex)) {
+        return prev.filter((ch) => ch !== channelIndex);
+      }
+      return [...prev, channelIndex];
+    });
+  };
+
+  useEffect(() => {
+    if (!streaming) {
+      return;
+    }
+    // Reiniciar stream al cambiar los canales seleccionados.
+    startStream();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedChannels, downsample]);
+
+  const chartData = useMemo(() => {
+    const datasets = Object.values(chartState.datasets).map((dataset) => ({
+      label: dataset.label,
+      data: dataset.data,
+      fill: false,
+      borderColor: dataset.borderColor,
+      tension: dataset.tension,
+      pointRadius: 0,
+    }));
+    return { labels: chartState.labels, datasets };
+  }, [chartState]);
+
+  return (
+    <SectionCard
+      id="preview"
+      title="Vista previa en tiempo real"
+      description="Monitorea muestras recientes desde la sesión de adquisición con vista previa."
+      actions={
+        <div className="actions">
+          <button type="button" className="secondary" onClick={stopStream} disabled={!streaming}>
+            Detener
+          </button>
+          <button type="button" onClick={startStream} disabled={!api || streaming}>
+            Iniciar vista previa
+          </button>
+        </div>
+      }
+    >
+      {!station ? (
+        <p>Configura la estación para habilitar la vista previa.</p>
+      ) : (
+        <div className="preview-grid">
+          <div className="preview-controls">
+            <fieldset>
+              <legend>Canales</legend>
+              {station.channels.map((channel) => (
+                <label key={channel.index} className="checkbox">
+                  <input
+                    type="checkbox"
+                    checked={selectedChannels.includes(channel.index)}
+                    onChange={() => toggleChannel(channel.index)}
+                    disabled={streaming}
+                  />
+                  <span>
+                    #{channel.index} · {channel.name}
+                  </span>
+                </label>
+              ))}
+              {station.channels.length === 0 && <p className="muted">No hay canales definidos.</p>}
+            </fieldset>
+            <label>
+              <span>Downsample</span>
+              <input
+                type="number"
+                min={1}
+                value={downsample}
+                onChange={(event) => setDownsample(Math.max(1, Number.parseInt(event.target.value, 10) || 1))}
+                disabled={streaming}
+              />
+            </label>
+            {!sessionReady && <p className="muted">Inicia una sesión con vista previa para habilitar el stream.</p>}
+          </div>
+          <div className="preview-chart">
+            {chartState.labels.length === 0 ? (
+              <p className="muted">No hay datos aún. Inicia la vista previa para poblar el gráfico.</p>
+            ) : (
+              <Line
+                data={chartData}
+                options={{
+                  responsive: true,
+                  maintainAspectRatio: false,
+                  scales: {
+                    x: {
+                      title: {
+                        display: true,
+                        text: "Tiempo (s)",
+                      },
+                    },
+                    y: {
+                      title: {
+                        display: true,
+                        text: "Valor",
+                      },
+                    },
+                  },
+                  plugins: {
+                    legend: {
+                      display: true,
+                      position: "bottom",
+                    },
+                  },
+                }}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/edge/webui/src/pages/ServiceStatusPanel.tsx
+++ b/edge/webui/src/pages/ServiceStatusPanel.tsx
@@ -1,0 +1,182 @@
+import { useMemo, useState } from "react";
+import { ApiClient, ApiError } from "../api";
+import { SectionCard } from "../components/SectionCard";
+import { SessionStatusResponse, StartSessionRequest } from "../types";
+
+interface ServiceStatusPanelProps {
+  api: ApiClient | null;
+  status: SessionStatusResponse | null;
+  loading: boolean;
+  onRefresh: () => void;
+  onSessionChanged: () => void;
+  onError: (message: string) => void;
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return "—";
+  }
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return value;
+  }
+}
+
+export function ServiceStatusPanel({ api, status, loading, onRefresh, onSessionChanged, onError }: ServiceStatusPanelProps) {
+  const [mode, setMode] = useState<StartSessionRequest["mode"]>("continuous");
+  const [preview, setPreview] = useState<boolean>(true);
+  const [busy, setBusy] = useState(false);
+
+  const activeSession = status?.active ? status.session : null;
+  const lastSession = !status?.active ? status?.last_session ?? null : null;
+
+  const canStart = useMemo(() => Boolean(api && !activeSession && !busy), [api, activeSession, busy]);
+  const canStop = useMemo(() => Boolean(api && activeSession && !busy), [api, activeSession, busy]);
+
+  const handleStart = async () => {
+    if (!api) return;
+    setBusy(true);
+    try {
+      await api.startAcquisition({ mode, preview });
+      onSessionChanged();
+    } catch (error) {
+      if (error instanceof ApiError) {
+        onError(error.message);
+      } else {
+        onError("No se pudo iniciar la sesión de adquisición.");
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleStop = async () => {
+    if (!api) return;
+    setBusy(true);
+    try {
+      await api.stopAcquisition();
+      onSessionChanged();
+    } catch (error) {
+      if (error instanceof ApiError) {
+        onError(error.message);
+      } else {
+        onError("No se pudo detener la sesión actual.");
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <SectionCard
+      id="status"
+      title="Estado del servicio"
+      description="Controla el ciclo de vida de la adquisición y supervisa el historial reciente."
+      actions={
+        <div className="actions">
+          <button type="button" className="secondary" onClick={onRefresh} disabled={loading || busy}>
+            Actualizar
+          </button>
+        </div>
+      }
+    >
+      <div className="status-grid">
+        <div>
+          <h3>Sesión activa</h3>
+          {activeSession ? (
+            <dl>
+              <div>
+                <dt>Modo</dt>
+                <dd>{activeSession.mode}</dd>
+              </div>
+              <div>
+                <dt>Vista previa</dt>
+                <dd>{activeSession.preview ? "Sí" : "No"}</dd>
+              </div>
+              <div>
+                <dt>Estado</dt>
+                <dd>{activeSession.status}</dd>
+              </div>
+              <div>
+                <dt>Inicio</dt>
+                <dd>{formatDate(activeSession.started_at)}</dd>
+              </div>
+              <div>
+                <dt>Última actualización</dt>
+                <dd>{formatDate(activeSession.finished_at)}</dd>
+              </div>
+              {activeSession.error && (
+                <div>
+                  <dt>Error</dt>
+                  <dd className="error-text">{activeSession.error}</dd>
+                </div>
+              )}
+            </dl>
+          ) : (
+            <p className="muted">No hay sesiones en ejecución.</p>
+          )}
+        </div>
+        <div>
+          <h3>Última sesión</h3>
+          {lastSession ? (
+            <dl>
+              <div>
+                <dt>Modo</dt>
+                <dd>{lastSession.mode}</dd>
+              </div>
+              <div>
+                <dt>Vista previa</dt>
+                <dd>{lastSession.preview ? "Sí" : "No"}</dd>
+              </div>
+              <div>
+                <dt>Estado</dt>
+                <dd>{lastSession.status}</dd>
+              </div>
+              <div>
+                <dt>Inicio</dt>
+                <dd>{formatDate(lastSession.started_at)}</dd>
+              </div>
+              <div>
+                <dt>Fin</dt>
+                <dd>{formatDate(lastSession.finished_at)}</dd>
+              </div>
+              {lastSession.error && (
+                <div>
+                  <dt>Error</dt>
+                  <dd className="error-text">{lastSession.error}</dd>
+                </div>
+              )}
+            </dl>
+          ) : (
+            <p className="muted">No hay registros previos.</p>
+          )}
+        </div>
+        <div>
+          <h3>Control</h3>
+          <div className="control-panel">
+            <label>
+              <span>Modo</span>
+              <select value={mode} onChange={(event) => setMode(event.target.value as StartSessionRequest["mode"])}>
+                <option value="continuous">Continuo</option>
+                <option value="timed">Temporizado</option>
+              </select>
+            </label>
+            <label className="checkbox">
+              <input type="checkbox" checked={preview} onChange={(event) => setPreview(event.target.checked)} />
+              <span>Habilitar vista previa</span>
+            </label>
+            <div className="actions">
+              <button type="button" onClick={handleStart} disabled={!canStart}>
+                {busy && !activeSession ? "Iniciando…" : "Iniciar"}
+              </button>
+              <button type="button" className="danger" onClick={handleStop} disabled={!canStop}>
+                {busy && activeSession ? "Deteniendo…" : "Detener"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/edge/webui/src/pages/StationConfigView.tsx
+++ b/edge/webui/src/pages/StationConfigView.tsx
@@ -1,0 +1,283 @@
+import { ChangeEvent } from "react";
+import { CalibrationInput } from "../components/CalibrationInput";
+import { SectionCard } from "../components/SectionCard";
+import { VoltageRangeSelect } from "../components/VoltageRangeSelect";
+import { StationConfig } from "../types";
+
+interface StationConfigViewProps {
+  config: StationConfig | null;
+  onChange: (config: StationConfig) => void;
+  onSubmit: () => void;
+  onRefresh: () => void;
+  dirty: boolean;
+  saving: boolean;
+  loading: boolean;
+}
+
+export function StationConfigView({
+  config,
+  onChange,
+  onSubmit,
+  onRefresh,
+  dirty,
+  saving,
+  loading,
+}: StationConfigViewProps) {
+  const handleMetaChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    if (!config) return;
+    const { name, value } = event.target;
+    if (name === "description") {
+      onChange({ ...config, description: value.trim() ? value : null });
+    } else {
+      onChange({ ...config, [name]: value });
+    }
+  };
+
+  const handleAcquisitionChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!config) return;
+    const { name, value } = event.target;
+    const parsed = value === "" ? null : Number.parseFloat(value);
+    if (value !== "" && !Number.isFinite(parsed)) {
+      return;
+    }
+    const acquisition = { ...config.acquisition } as StationConfig["acquisition"] & Record<string, unknown>;
+    if (name === "sample_rate_hz" && parsed !== null) {
+      acquisition.sample_rate_hz = parsed;
+    } else if (name === "block_size" && parsed !== null) {
+      acquisition.block_size = parsed;
+    } else if (name === "duration_s") {
+      acquisition.duration_s = parsed;
+    } else if (name === "total_samples") {
+      acquisition.total_samples = parsed === null ? null : Math.trunc(parsed);
+    } else if (name === "correction_threshold_ns") {
+      const drift = { ...config.acquisition.drift_detection };
+      if (parsed === null) {
+        drift.correction_threshold_ns = null;
+      } else if (Number.isFinite(parsed)) {
+        drift.correction_threshold_ns = Math.trunc(parsed);
+      }
+      acquisition.drift_detection = drift;
+    }
+    onChange({ ...config, acquisition } as StationConfig);
+  };
+
+  const handleChannelChange = (index: number, field: string, value: unknown) => {
+    if (!config) return;
+    if (field === "index" && typeof value === "number" && Number.isNaN(value)) {
+      return;
+    }
+    const channels = config.channels.map((channel, i) =>
+      i === index
+        ? {
+            ...channel,
+            [field]: value,
+          }
+        : channel,
+    );
+    onChange({ ...config, channels });
+  };
+
+  const handleAddChannel = () => {
+    if (!config) return;
+    const nextIndex =
+      config.channels.reduce((max, channel) => Math.max(max, channel.index), -1) + 1;
+    const newChannel = {
+      index: nextIndex,
+      name: `Canal ${nextIndex}`,
+      unit: "V",
+      voltage_range: 10,
+      calibration: { gain: 1, offset: 0 },
+    };
+    onChange({ ...config, channels: [...config.channels, newChannel] });
+  };
+
+  const handleRemoveChannel = (idx: number) => {
+    if (!config) return;
+    const target = config.channels[idx];
+    if (!confirm(`¿Eliminar canal ${target?.name ?? idx}?`)) {
+      return;
+    }
+    onChange({ ...config, channels: config.channels.filter((_, i) => i !== idx) });
+  };
+
+  return (
+    <SectionCard
+      id="station"
+      title="Configuración MCC128"
+      description="Define canales, calibraciones y parámetros de adquisición."
+      actions={
+        <div className="actions">
+          <button type="button" className="secondary" onClick={onRefresh} disabled={loading || saving}>
+            Recargar
+          </button>
+          <button type="button" onClick={onSubmit} disabled={!dirty || saving || !config}>
+            {saving ? "Guardando…" : "Guardar"}
+          </button>
+        </div>
+      }
+    >
+      {!config ? (
+        <p>{loading ? "Cargando configuración…" : "No hay datos de estación disponibles."}</p>
+      ) : (
+        <form className="form-grid" onSubmit={(event) => event.preventDefault()}>
+          <div className="grid-columns">
+            <label>
+              <span>ID de estación</span>
+              <input
+                type="text"
+                name="station_id"
+                value={config.station_id}
+                onChange={handleMetaChange}
+                required
+              />
+            </label>
+            <label>
+              <span>Descripción</span>
+              <input
+                type="text"
+                name="description"
+                value={config.description ?? ""}
+                onChange={handleMetaChange}
+                placeholder="Opcional"
+              />
+            </label>
+          </div>
+
+          <fieldset>
+            <legend>Adquisición</legend>
+            <div className="grid-columns">
+              <label>
+                <span>Sample rate (Hz)</span>
+                <input
+                  type="number"
+                  name="sample_rate_hz"
+                  min="1"
+                  step="0.1"
+                  value={config.acquisition.sample_rate_hz}
+                  onChange={handleAcquisitionChange}
+                  required
+                />
+              </label>
+              <label>
+                <span>Block size</span>
+                <input
+                  type="number"
+                  name="block_size"
+                  min="1"
+                  step="1"
+                  value={config.acquisition.block_size}
+                  onChange={handleAcquisitionChange}
+                  required
+                />
+              </label>
+              <label>
+                <span>Duración (s)</span>
+                <input
+                  type="number"
+                  name="duration_s"
+                  min="0"
+                  step="0.1"
+                  value={config.acquisition.duration_s ?? ""}
+                  onChange={handleAcquisitionChange}
+                />
+              </label>
+              <label>
+                <span>Total samples</span>
+                <input
+                  type="number"
+                  name="total_samples"
+                  min="0"
+                  step="1"
+                  value={config.acquisition.total_samples ?? ""}
+                  onChange={handleAcquisitionChange}
+                />
+              </label>
+              <label>
+                <span>Corrección drift (ns)</span>
+                <input
+                  type="number"
+                  name="correction_threshold_ns"
+                  min="0"
+                  step="1"
+                  value={config.acquisition.drift_detection.correction_threshold_ns ?? ""}
+                  onChange={handleAcquisitionChange}
+                />
+              </label>
+            </div>
+          </fieldset>
+
+          <div className="channels-header">
+            <h3>Canales configurados</h3>
+            <button type="button" className="secondary" onClick={handleAddChannel}>
+              Añadir canal
+            </button>
+          </div>
+
+          <div className="channels-list">
+            {config.channels.map((channel, idx) => (
+              <div key={`${channel.index}-${idx}`} className="channel-card">
+                <div className="channel-title">
+                  <h4>
+                    #{channel.index} · {channel.name}
+                  </h4>
+                  <button
+                    type="button"
+                    className="danger"
+                    onClick={() => handleRemoveChannel(idx)}
+                    title="Eliminar canal"
+                  >
+                    Eliminar
+                  </button>
+                </div>
+                <div className="grid-columns">
+                  <label>
+                    <span>Índice</span>
+                    <input
+                      type="number"
+                      value={channel.index}
+                      min={0}
+                      step={1}
+                      onChange={(event) => handleChannelChange(idx, "index", Number.parseInt(event.target.value, 10))}
+                    />
+                  </label>
+                  <label>
+                    <span>Nombre</span>
+                    <input
+                      type="text"
+                      value={channel.name}
+                      onChange={(event) => handleChannelChange(idx, "name", event.target.value)}
+                    />
+                  </label>
+                  <label>
+                    <span>Unidad</span>
+                    <input
+                      type="text"
+                      value={channel.unit}
+                      onChange={(event) => handleChannelChange(idx, "unit", event.target.value)}
+                    />
+                  </label>
+                </div>
+                <label className="voltage-field">
+                  <span>Rango de voltaje</span>
+                  <VoltageRangeSelect
+                    value={channel.voltage_range}
+                    onChange={(value) => handleChannelChange(idx, "voltage_range", value)}
+                  />
+                </label>
+                <div>
+                  <span>Calibración</span>
+                  <CalibrationInput
+                    value={channel.calibration}
+                    onChange={(value) => handleChannelChange(idx, "calibration", value)}
+                  />
+                </div>
+              </div>
+            ))}
+            {config.channels.length === 0 && <p>No hay canales configurados.</p>}
+          </div>
+        </form>
+      )}
+      {dirty && <p className="muted">Hay cambios sin guardar.</p>}
+    </SectionCard>
+  );
+}

--- a/edge/webui/src/pages/StorageSettingsView.tsx
+++ b/edge/webui/src/pages/StorageSettingsView.tsx
@@ -1,0 +1,356 @@
+import { ChangeEvent } from "react";
+import { SectionCard } from "../components/SectionCard";
+import { SinkToggle } from "../components/SinkToggle";
+import { StorageSettings } from "../types";
+
+interface StorageSettingsViewProps {
+  settings: StorageSettings | null;
+  onChange: (settings: StorageSettings) => void;
+  onSubmit: () => void;
+  onRefresh: () => void;
+  dirty: boolean;
+  saving: boolean;
+  loading: boolean;
+}
+
+export function StorageSettingsView({
+  settings,
+  onChange,
+  onSubmit,
+  onRefresh,
+  dirty,
+  saving,
+  loading,
+}: StorageSettingsViewProps) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    if (!settings) return;
+    const { name, value, checked } = event.target as HTMLInputElement;
+    const next: StorageSettings = { ...settings };
+    if (name === "verify_ssl") {
+      next.verify_ssl = checked;
+    } else if (name === "driver" || name === "url" || name === "org" || name === "bucket" || name === "token") {
+      (next as any)[name] = value;
+    } else if (name === "batch_size" || name === "queue_max_size") {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isNaN(parsed)) {
+        return;
+      }
+      (next as any)[name] = parsed;
+    } else if (name === "timeout_s") {
+      const parsed = Number.parseFloat(value);
+      if (Number.isNaN(parsed)) {
+        return;
+      }
+      next.timeout_s = parsed;
+    }
+    onChange(next);
+  };
+
+  const handleRetryChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!settings) return;
+    const { name, value } = event.target;
+    const retry = { ...settings.retry };
+    if (name === "max_attempts") {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isNaN(parsed)) {
+        return;
+      }
+      retry.max_attempts = parsed;
+    } else if (name === "base_delay_s") {
+      const parsed = Number.parseFloat(value);
+      if (Number.isNaN(parsed)) {
+        return;
+      }
+      retry.base_delay_s = parsed;
+    } else if (name === "max_backoff_s") {
+      if (value === "") {
+        retry.max_backoff_s = null;
+      } else {
+        const parsed = Number.parseFloat(value);
+        if (Number.isNaN(parsed)) {
+          return;
+        }
+        retry.max_backoff_s = parsed;
+      }
+    }
+    onChange({ ...settings, retry });
+  };
+
+  const handleCsvChange = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    if (!settings) return;
+    const { name, value, checked } = event.target as HTMLInputElement;
+    const csv = { ...settings.csv };
+    if (name === "rotation") {
+      csv.rotation = value as typeof csv.rotation;
+    } else if (name === "write_headers") {
+      csv.write_headers = checked;
+    } else {
+      (csv as any)[name] = value;
+    }
+    onChange({ ...settings, csv });
+  };
+
+  const handleFtpChange = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    if (!settings) return;
+    const { name, value, checked } = event.target as HTMLInputElement;
+    const ftp = { ...settings.ftp };
+    if (name === "protocol") {
+      ftp.protocol = value as typeof ftp.protocol;
+    } else if (name === "passive") {
+      ftp.passive = checked;
+    } else if (name === "port") {
+      if (value === "") {
+        ftp.port = null;
+      } else {
+        const parsed = Number.parseInt(value, 10);
+        if (Number.isNaN(parsed)) {
+          return;
+        }
+        ftp.port = parsed;
+      }
+    } else if (name === "upload_interval_s") {
+      if (value === "") {
+        ftp.upload_interval_s = null;
+      } else {
+        const parsed = Number.parseFloat(value);
+        if (Number.isNaN(parsed)) {
+          return;
+        }
+        ftp.upload_interval_s = parsed;
+      }
+    } else {
+      (ftp as any)[name] = value === "" ? null : value;
+    }
+    onChange({ ...settings, ftp });
+  };
+
+  const handleSinkToggle = (sink: string, enabled: boolean) => {
+    if (!settings) return;
+    if (sink === settings.driver && !enabled) {
+      alert("El driver principal no se puede deshabilitar.");
+      return;
+    }
+    const sinks = updateSinks(settings.sinks, sink, enabled);
+    if (sink === "csv") {
+      onChange({ ...settings, sinks, csv: { ...settings.csv, enabled } });
+    } else if (sink === "ftp") {
+      onChange({ ...settings, sinks, ftp: { ...settings.ftp, enabled } });
+    } else {
+      onChange({ ...settings, sinks });
+    }
+  };
+
+  const updateSinks = (current: string[], sink: string, enabled: boolean) => {
+    const set = new Set(current);
+    if (enabled) {
+      set.add(sink);
+    } else {
+      set.delete(sink);
+    }
+    return Array.from(set);
+  };
+
+  return (
+    <SectionCard
+      id="storage"
+      title="Almacenamiento"
+      description="Configura InfluxDB y sinks secundarios como CSV o FTP."
+      actions={
+        <div className="actions">
+          <button type="button" className="secondary" onClick={onRefresh} disabled={loading || saving}>
+            Recargar
+          </button>
+          <button type="button" onClick={onSubmit} disabled={!dirty || saving || !settings}>
+            {saving ? "Guardando…" : "Guardar"}
+          </button>
+        </div>
+      }
+    >
+      {!settings ? (
+        <p>{loading ? "Cargando configuración…" : "No hay configuración de almacenamiento."}</p>
+      ) : (
+        <form className="form-grid" onSubmit={(event) => event.preventDefault()}>
+          <fieldset>
+            <legend>InfluxDB</legend>
+            <div className="grid-columns">
+              <label>
+                <span>Driver</span>
+                <input type="text" name="driver" value={settings.driver} onChange={handleChange} />
+              </label>
+              <label>
+                <span>URL</span>
+                <input type="url" name="url" value={settings.url} onChange={handleChange} required />
+              </label>
+              <label>
+                <span>Organización</span>
+                <input type="text" name="org" value={settings.org} onChange={handleChange} required />
+              </label>
+              <label>
+                <span>Bucket</span>
+                <input type="text" name="bucket" value={settings.bucket} onChange={handleChange} required />
+              </label>
+            </div>
+            <label>
+              <span>Token</span>
+              <input type="password" name="token" value={settings.token} onChange={handleChange} required />
+            </label>
+            <div className="grid-columns">
+              <label>
+                <span>Batch size</span>
+                <input type="number" name="batch_size" min="1" value={settings.batch_size} onChange={handleChange} />
+              </label>
+              <label>
+                <span>Timeout (s)</span>
+                <input type="number" name="timeout_s" min="0" step="0.1" value={settings.timeout_s} onChange={handleChange} />
+              </label>
+              <label>
+                <span>Queue max</span>
+                <input type="number" name="queue_max_size" min="1" value={settings.queue_max_size} onChange={handleChange} />
+              </label>
+              <label className="checkbox">
+                <input type="checkbox" name="verify_ssl" checked={settings.verify_ssl} onChange={handleChange} />
+                <span>Verificar SSL</span>
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>Reintentos</legend>
+            <div className="grid-columns">
+              <label>
+                <span>Máx. intentos</span>
+                <input type="number" name="max_attempts" min="1" value={settings.retry.max_attempts} onChange={handleRetryChange} />
+              </label>
+              <label>
+                <span>Delay base (s)</span>
+                <input type="number" name="base_delay_s" min="0" step="0.1" value={settings.retry.base_delay_s} onChange={handleRetryChange} />
+              </label>
+              <label>
+                <span>Backoff máx. (s)</span>
+                <input
+                  type="number"
+                  name="max_backoff_s"
+                  min="0"
+                  step="0.1"
+                  value={settings.retry.max_backoff_s ?? ""}
+                  onChange={handleRetryChange}
+                />
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>Sinks activos</legend>
+            <div className="sinks-grid">
+              <SinkToggle sink={settings.driver} label="Influx" enabled={true} onToggle={() => null} disabled />
+              <SinkToggle sink="csv" label="CSV" enabled={settings.csv.enabled} onToggle={handleSinkToggle} />
+              <SinkToggle sink="ftp" label="FTP" enabled={settings.ftp.enabled} onToggle={handleSinkToggle} />
+            </div>
+          </fieldset>
+
+          <fieldset disabled={!settings.csv.enabled}>
+            <legend>CSV</legend>
+            <div className="grid-columns">
+              <label>
+                <span>Directorio</span>
+                <input type="text" name="directory" value={settings.csv.directory} onChange={handleCsvChange} />
+              </label>
+              <label>
+                <span>Rotación</span>
+                <select name="rotation" value={settings.csv.rotation} onChange={handleCsvChange}>
+                  <option value="session">Por sesión</option>
+                  <option value="daily">Diaria</option>
+                </select>
+              </label>
+              <label>
+                <span>Prefijo</span>
+                <input type="text" name="filename_prefix" value={settings.csv.filename_prefix} onChange={handleCsvChange} />
+              </label>
+            </div>
+            <div className="grid-columns">
+              <label>
+                <span>Formato timestamp</span>
+                <input type="text" name="timestamp_format" value={settings.csv.timestamp_format} onChange={handleCsvChange} />
+              </label>
+              <label>
+                <span>Delimitador</span>
+                <input type="text" name="delimiter" value={settings.csv.delimiter} onChange={handleCsvChange} />
+              </label>
+              <label>
+                <span>Decimal</span>
+                <input type="text" name="decimal" value={settings.csv.decimal} onChange={handleCsvChange} />
+              </label>
+              <label>
+                <span>Encoding</span>
+                <input type="text" name="encoding" value={settings.csv.encoding} onChange={handleCsvChange} />
+              </label>
+            </div>
+            <label>
+              <span>Salto de línea</span>
+              <input type="text" name="newline" value={settings.csv.newline} onChange={handleCsvChange} />
+            </label>
+            <label className="checkbox">
+              <input type="checkbox" name="write_headers" checked={settings.csv.write_headers} onChange={handleCsvChange} />
+              <span>Incluir cabeceras</span>
+            </label>
+          </fieldset>
+
+          <fieldset disabled={!settings.ftp.enabled}>
+            <legend>FTP / SFTP</legend>
+            <div className="grid-columns">
+              <label>
+                <span>Protocolo</span>
+                <select name="protocol" value={settings.ftp.protocol} onChange={handleFtpChange}>
+                  <option value="ftp">FTP</option>
+                  <option value="sftp">SFTP</option>
+                </select>
+              </label>
+              <label>
+                <span>Host</span>
+                <input type="text" name="host" value={settings.ftp.host ?? ""} onChange={handleFtpChange} />
+              </label>
+              <label>
+                <span>Puerto</span>
+                <input type="number" name="port" value={settings.ftp.port ?? ""} onChange={handleFtpChange} />
+              </label>
+              <label>
+                <span>Usuario</span>
+                <input type="text" name="username" value={settings.ftp.username ?? ""} onChange={handleFtpChange} />
+              </label>
+              <label>
+                <span>Contraseña</span>
+                <input type="password" name="password" value={settings.ftp.password ?? ""} onChange={handleFtpChange} />
+              </label>
+            </div>
+            <div className="grid-columns">
+              <label>
+                <span>Directorio remoto</span>
+                <input type="text" name="remote_dir" value={settings.ftp.remote_dir} onChange={handleFtpChange} />
+              </label>
+              <label>
+                <span>Directorio local</span>
+                <input type="text" name="local_dir" value={settings.ftp.local_dir ?? ""} onChange={handleFtpChange} />
+              </label>
+              <label>
+                <span>Rotación</span>
+                <select name="rotation" value={settings.ftp.rotation} onChange={handleFtpChange}>
+                  <option value="session">Por sesión</option>
+                  <option value="periodic">Periódica</option>
+                </select>
+              </label>
+              <label>
+                <span>Intervalo subida (s)</span>
+                <input type="number" name="upload_interval_s" min="0" step="0.1" value={settings.ftp.upload_interval_s ?? ""} onChange={handleFtpChange} />
+              </label>
+              <label className="checkbox">
+                <input type="checkbox" name="passive" checked={settings.ftp.passive} onChange={handleFtpChange} />
+                <span>Pasivo</span>
+              </label>
+            </div>
+          </fieldset>
+        </form>
+      )}
+      {dirty && <p className="muted">Hay cambios sin guardar.</p>}
+    </SectionCard>
+  );
+}

--- a/edge/webui/src/styles/index.css
+++ b/edge/webui/src/styles/index.css
@@ -1,0 +1,314 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(14, 116, 144, 0.25), transparent 60%), #0f172a;
+}
+
+.app-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app-header {
+  text-align: center;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.app-header h1 {
+  font-size: 2.5rem;
+  margin: 0;
+  color: #38bdf8;
+}
+
+.muted {
+  color: #94a3b8;
+  font-size: 0.95rem;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.section-card {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(12px);
+}
+
+.section-card header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.section-card h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.section-card .actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.section-card button {
+  background: #38bdf8;
+  border: none;
+  color: #0f172a;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.section-card button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(56, 189, 248, 0.35);
+}
+
+.section-card button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.secondary {
+  background: transparent;
+  color: #38bdf8;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+button.danger {
+  background: #f87171;
+  color: #0f172a;
+}
+
+.form-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.grid-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+label span {
+  color: #cbd5f5;
+  font-weight: 600;
+}
+
+input,
+select,
+textarea {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 0.55rem 0.75rem;
+  color: #e2e8f0;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+fieldset {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+  color: #38bdf8;
+}
+
+.channels-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.channels-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.channel-card {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.channel-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.calibration-input,
+.voltage-select {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.voltage-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.voltage-select select {
+  min-width: 140px;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+}
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: rgba(248, 113, 113, 0.2);
+  border: 1px solid rgba(248, 113, 113, 0.5);
+  color: #fecaca;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+}
+
+.error-banner button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.error-text {
+  color: #fecaca;
+}
+
+.token-manager {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+  background: rgba(15, 23, 42, 0.5);
+  padding: 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.token-manager .actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.preview-grid {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 1.25rem;
+}
+
+.preview-chart {
+  min-height: 320px;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.status-grid dl {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.status-grid dt {
+  font-weight: 600;
+  color: #38bdf8;
+}
+
+.status-grid dd {
+  margin: 0;
+}
+
+.control-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.loading {
+  text-align: center;
+  color: #38bdf8;
+}
+
+@media (max-width: 960px) {
+  .preview-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .section-card {
+    padding: 1.25rem;
+  }
+
+  .token-manager {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/edge/webui/src/types.ts
+++ b/edge/webui/src/types.ts
@@ -1,0 +1,126 @@
+export interface Calibration {
+  gain: number;
+  offset: number;
+}
+
+export interface ChannelConfig {
+  index: number;
+  name: string;
+  unit: string;
+  voltage_range: number;
+  calibration: Calibration;
+}
+
+export interface DriftDetectionSettings {
+  correction_threshold_ns: number | null;
+}
+
+export interface AcquisitionSettings {
+  sample_rate_hz: number;
+  block_size: number;
+  duration_s: number | null;
+  total_samples: number | null;
+  drift_detection: DriftDetectionSettings;
+}
+
+export interface StationConfig {
+  station_id: string;
+  description?: string | null;
+  acquisition: AcquisitionSettings;
+  channels: ChannelConfig[];
+}
+
+export interface RetrySettings {
+  max_attempts: number;
+  base_delay_s: number;
+  max_backoff_s: number | null;
+}
+
+export interface CSVSinkSettings {
+  enabled: boolean;
+  directory: string;
+  rotation: "session" | "daily";
+  filename_prefix: string;
+  timestamp_format: string;
+  delimiter: string;
+  decimal: string;
+  encoding: string;
+  newline: string;
+  write_headers: boolean;
+}
+
+export interface FTPSinkSettings {
+  enabled: boolean;
+  protocol: "ftp" | "sftp";
+  host: string | null;
+  port: number | null;
+  username: string | null;
+  password: string | null;
+  remote_dir: string;
+  local_dir: string | null;
+  rotation: "session" | "periodic";
+  upload_interval_s: number | null;
+  passive: boolean;
+}
+
+export interface StorageSettings {
+  driver: string;
+  url: string;
+  org: string;
+  bucket: string;
+  token: string;
+  batch_size: number;
+  timeout_s: number;
+  queue_max_size: number;
+  verify_ssl: boolean;
+  retry: RetrySettings;
+  sinks: string[];
+  csv: CSVSinkSettings;
+  ftp: FTPSinkSettings;
+}
+
+export interface SessionSummary {
+  mode: "continuous" | "timed";
+  preview: boolean;
+  status: string;
+  started_at: string;
+  finished_at: string | null;
+  station_id: string;
+  error: string | null;
+}
+
+export interface SessionStatusResponse {
+  active: boolean;
+  session?: SessionSummary;
+  last_session?: SessionSummary | null;
+}
+
+export interface StartSessionRequest {
+  mode: "continuous" | "timed";
+  preview: boolean;
+}
+
+export interface StopResponse {
+  message: string;
+  session: SessionSummary;
+}
+
+export interface PreviewChannelPayload {
+  index: number;
+  name: string;
+  unit: string;
+  values: number[];
+}
+
+export interface PreviewMessagePayload {
+  station_id: string;
+  captured_at_ns: number;
+  timestamps_ns: number[];
+  channels: PreviewChannelPayload[];
+}
+
+export interface PreviewStreamOptions {
+  channels?: number[];
+  max_duration_s?: number;
+  downsample?: number;
+}

--- a/edge/webui/tsconfig.json
+++ b/edge/webui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["node"],
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/edge/webui/tsconfig.node.json
+++ b/edge/webui/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts", "scripts/**/*.ts"]
+}

--- a/edge/webui/vite.config.ts
+++ b/edge/webui/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, loadEnv } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    plugins: [react()],
+    base: env.VITE_PUBLIC_PATH || "/",
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "src"),
+      },
+    },
+    build: {
+      outDir: "dist",
+      sourcemap: true,
+    },
+    server: {
+      port: Number(env.VITE_DEV_PORT || 5173),
+      proxy: env.VITE_API_PROXY
+        ? {
+            [env.VITE_API_PROXY]: {
+              target: env.VITE_API_TARGET || "http://127.0.0.1:8000",
+              changeOrigin: true,
+              rewrite: (path) => path.replace(env.VITE_API_PROXY as string, ""),
+            },
+          }
+        : undefined,
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- bootstrap a Vite + React project under `edge/webui` with build, lint and deployment scripts that output to `edge/webui/dist`
- implement MCC128 configuration, storage settings, live preview and service status views with reusable form components and realtime charting
- add an API client handling bearer authentication, validation errors and SSE preview streaming plus styling assets and deployment helper script

## Testing
- `npm install` *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d09d8309d08331bbc8381c6223cde3