### PR TITLE
ci: add frontend workflow job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  tests:
+  backend-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -21,5 +21,33 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt pytest
 
-      - name: Run tests
+      - name: Run pytest suite
         run: pytest
+
+  frontend-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: edge/webui
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: edge/webui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Run E2E tests
+        run: npm run test:e2e


### PR DESCRIPTION
## Summary
- split the workflow into parallel backend and frontend jobs
- install Node.js with npm caching to build the web UI and run its e2e tests
- install Playwright browsers before executing the frontend test suite

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d0b9a49ab48331bd233cd2ae1bef9c