### PR TITLE
Refactor scr package imports to use relative paths

### DIFF
--- a/edge/scr/__init__.py
+++ b/edge/scr/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities for MCC128 data acquisition scripts."""
+
+__all__ = [
+    "acquire",
+    "acquisition",
+    "calibrate",
+    "mcc_reader",
+    "preview",
+    "sender",
+    "sinks",
+]

--- a/edge/scr/acquire.py
+++ b/edge/scr/acquire.py
@@ -1,16 +1,9 @@
 import logging
-import sys
-from pathlib import Path
-
-# Ensure the repository root (edge parent) is importable when executed as script.
-ROOT = Path(__file__).resolve().parents[2]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
 from edge.config.schema import StationConfig, StorageSettings
 from edge.config.store import load_station_config, load_storage_settings
 
-from acquisition import AcquisitionRunner, _consume_block_timestamps
+from .acquisition import AcquisitionRunner, _consume_block_timestamps
 
 __all__ = [
     "main",
@@ -19,6 +12,8 @@ __all__ = [
 
 
 logger = logging.getLogger(__name__)
+
+
 def main(station: StationConfig | None = None, storage: StorageSettings | None = None):
     if not logging.getLogger().hasHandlers():
         logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")

--- a/edge/scr/acquisition.py
+++ b/edge/scr/acquisition.py
@@ -9,9 +9,9 @@ from typing import Callable, Dict, List, Optional, Protocol, Sequence, runtime_c
 
 from edge.config.schema import StationConfig, StorageSettings
 
-from calibrate import apply_calibration
-from mcc_reader import open_mcc128, read_block, start_scan
-from sinks import Sample, SampleSink, build_sinks
+from .calibrate import apply_calibration
+from .mcc_reader import open_mcc128, read_block, start_scan
+from .sinks import Sample, SampleSink, build_sinks
 
 logger = logging.getLogger(__name__)
 

--- a/edge/scr/preview.py
+++ b/edge/scr/preview.py
@@ -9,7 +9,7 @@ from typing import AsyncIterator, Iterable, List, Optional, Sequence
 
 from edge.config.schema import ChannelConfig, StationConfig
 
-from acquisition import CalibratedBlock, CalibratedChannelBlock
+from .acquisition import CalibratedBlock, CalibratedChannelBlock
 
 logger = logging.getLogger(__name__)
 

--- a/edge/scr/sender.py
+++ b/edge/scr/sender.py
@@ -1,5 +1,5 @@
 """Compatibilidad hacia atrás para importaciones previas de InfluxSender."""
 
-from sinks.influx import InfluxSender, to_line
+from .sinks.influx import InfluxSender, to_line
 
 __all__ = ["InfluxSender", "to_line"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration ensuring package imports are available."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_acquire_timestamps.py
+++ b/tests/test_acquire_timestamps.py
@@ -1,11 +1,4 @@
-import sys
-from pathlib import Path
-
-
-# Allow importing scripts from the edge/scr directory.
-sys.path.append(str(Path(__file__).resolve().parents[1] / "edge" / "scr"))
-
-from acquire import _consume_block_timestamps  # type: ignore  # noqa: E402
+from edge.scr.acquire import _consume_block_timestamps  # type: ignore  # noqa: E402
 
 
 def test_consecutive_blocks_preserve_ts_step():

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -8,13 +8,8 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-# Allow importing scripts from the edge/scr directory.
-SCR_PATH = ROOT / "edge" / "scr"
-if str(SCR_PATH) not in sys.path:
-    sys.path.append(str(SCR_PATH))
-
 from edge.config import load_station_config  # type: ignore  # noqa: E402
-from calibrate import apply_calibration  # type: ignore  # noqa: E402
+from edge.scr.calibrate import apply_calibration  # type: ignore  # noqa: E402
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -9,13 +9,8 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-# Allow importing scripts from the edge/scr directory.
-SCR_PATH = ROOT / "edge" / "scr"
-if str(SCR_PATH) not in sys.path:
-    sys.path.append(str(SCR_PATH))
-
 from edge.config.schema import RetrySettings, StorageSettings  # type: ignore  # noqa: E402
-from sender import InfluxSender  # type: ignore  # noqa: E402
+from edge.scr.sender import InfluxSender  # type: ignore  # noqa: E402
 
 
 WRITE_URL = "http://example.com/api/v2/write?org=org&bucket=bucket&precision=ns"


### PR DESCRIPTION
## Summary
- declare `edge.scr` as a package so its modules can be imported via package paths
- switch the acquisition, preview, acquire, and sender scripts to use relative imports and drop direct sys.path manipulation
- update tests to import through `edge.scr`, add a shared conftest to expose the repo root on sys.path, and clean up old path hacks

## Testing
- `pytest` *(fails: starlette.testclient requires the optional httpx dependency; pip installation is blocked in this environment)*
- `python -m edge.webapi.main`


------
https://chatgpt.com/codex/tasks/task_e_68d0c9da6b848331b7d042b5e8ad0981