### PR TITLE
Fix MCC128 differential mode enum

### DIFF
--- a/edge/scr/mcc_reader.py
+++ b/edge/scr/mcc_reader.py
@@ -82,7 +82,7 @@ def start_scan(
     ch_mask = 0
     for ch in channels:
         ch_mask |= 1 << ch
-    board.a_in_mode_write(AnalogInputMode.DIFFERENTIAL)
+    board.a_in_mode_write(AnalogInputMode.DIFF)
     board.a_in_range_write(resolve_input_range(channel_ranges))
     board.a_in_scan_start(
         channel_mask=ch_mask,


### PR DESCRIPTION
## Summary
- correct the MCC128 differential input mode to use the existing AnalogInputMode.DIFF constant

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68d0d901bef88331ba474fe066052372