### PR TITLE
Add system time synchronization controls to API and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 __pycache__/
 venv*/
 .vscode
+node_modules/
+dist/
+*.py[cod]
+*.tsbuildinfo

--- a/edge/webapi/__init__.py
+++ b/edge/webapi/__init__.py
@@ -7,12 +7,14 @@ from fastapi import FastAPI
 from .acquisition import router as acquisition_router
 from .configuration import router as config_router
 from .preview import router as preview_router
+from .system import router as system_router
 
 app = FastAPI(title="MCC128 Edge Web API", version="1.0.0")
 
 app.include_router(config_router)
 app.include_router(acquisition_router)
 app.include_router(preview_router)
+app.include_router(system_router)
 
 
 __all__ = ["app"]

--- a/edge/webapi/system.py
+++ b/edge/webapi/system.py
@@ -1,0 +1,211 @@
+"""System status endpoints (time synchronization, etc.)."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from typing import Iterable
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from .auth import require_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/system",
+    tags=["system"],
+    dependencies=[Depends(require_token)],
+)
+
+
+class TimeStatus(BaseModel):
+    """Expose information about the current system time and NTP status."""
+
+    system_time: datetime
+    timezone: str | None = None
+    ntp_enabled: bool | None = None
+    ntp_synchronized: bool | None = None
+    last_successful_sync: datetime | None = None
+    last_attempt_sync: datetime | None = None
+    server_name: str | None = None
+    server_address: str | None = None
+
+
+class SyncTimeResponse(BaseModel):
+    """Response payload for the NTP sync action."""
+
+    message: str
+    warnings: list[str]
+    time: TimeStatus
+
+
+def _parse_bool(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def _parse_usec(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        microseconds = int(value)
+    except ValueError:
+        return None
+    if microseconds <= 0:
+        return None
+    # systemd exposes timestamps in microseconds since the UNIX epoch (UTC)
+    timestamp = datetime.fromtimestamp(microseconds / 1_000_000, tz=timezone.utc)
+    return timestamp.astimezone()
+
+
+def _parse_key_value(output: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in output.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key:
+            data[key] = value
+    return data
+
+
+def _run_command(args: Iterable[str]) -> str:
+    args_list = list(args)
+    try:
+        completed = subprocess.run(
+            args_list,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Comando no encontrado: {args_list!r}") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() if exc.stderr else exc.stdout.strip()
+        detail = f": {stderr}" if stderr else ""
+        raise RuntimeError(
+            f"El comando {' '.join(args_list)} finalizó con código {exc.returncode}{detail}"
+        ) from exc
+    return completed.stdout
+
+
+def _gather_time_status() -> TimeStatus:
+    system_time = datetime.now().astimezone()
+    timezone_name: str | None = None
+    ntp_enabled: bool | None = None
+    ntp_synchronized: bool | None = None
+    last_successful_sync: datetime | None = None
+    last_attempt_sync: datetime | None = None
+    server_name: str | None = None
+    server_address: str | None = None
+
+    try:
+        show_output = _run_command(
+            [
+                "timedatectl",
+                "show",
+                "--property=Timezone",
+                "--property=NTPSyncEnabled",
+                "--property=NTPSynchronized",
+                "--property=TimeUSec",
+            ]
+        )
+    except RuntimeError as exc:
+        logger.debug("No se pudo obtener el estado horario principal: %s", exc)
+    else:
+        info = _parse_key_value(show_output)
+        timezone_name = info.get("Timezone") or None
+        ntp_enabled = _parse_bool(info.get("NTPSyncEnabled"))
+        ntp_synchronized = _parse_bool(info.get("NTPSynchronized"))
+        parsed_time = _parse_usec(info.get("TimeUSec"))
+        if parsed_time is not None:
+            system_time = parsed_time
+
+    try:
+        timesync_output = _run_command(
+            [
+                "timedatectl",
+                "show-timesync",
+                "--property=ServerName",
+                "--property=ServerAddress",
+                "--property=LastSuccessfulSyncUSec",
+                "--property=LastAttemptSyncUSec",
+                "--property=LastSyncUSec",
+            ]
+        )
+    except RuntimeError as exc:
+        logger.debug("No se pudo obtener el estado de timesyncd: %s", exc)
+    else:
+        info = _parse_key_value(timesync_output)
+        server_name = info.get("ServerName") or None
+        server_address = info.get("ServerAddress") or None
+        last_successful_sync = _parse_usec(info.get("LastSuccessfulSyncUSec"))
+        last_attempt_sync = _parse_usec(info.get("LastAttemptSyncUSec"))
+        if last_successful_sync is None:
+            last_successful_sync = _parse_usec(info.get("LastSyncUSec"))
+
+    return TimeStatus(
+        system_time=system_time,
+        timezone=timezone_name,
+        ntp_enabled=ntp_enabled,
+        ntp_synchronized=ntp_synchronized,
+        last_successful_sync=last_successful_sync,
+        last_attempt_sync=last_attempt_sync,
+        server_name=server_name,
+        server_address=server_address,
+    )
+
+
+@router.get("/time", response_model=TimeStatus)
+async def get_time_status() -> TimeStatus:
+    """Return the current system time information."""
+
+    return _gather_time_status()
+
+
+@router.post("/time/sync", response_model=SyncTimeResponse, status_code=status.HTTP_200_OK)
+async def sync_time() -> SyncTimeResponse:
+    """Trigger a synchronization attempt with the configured NTP source."""
+
+    warnings: list[str] = []
+
+    try:
+        _run_command(["timedatectl", "set-ntp", "true"])
+    except RuntimeError as exc:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))
+
+    systemctl_path = shutil.which("systemctl")
+    if systemctl_path:
+        try:
+            _run_command([systemctl_path, "restart", "systemd-timesyncd.service"])
+        except RuntimeError as exc:
+            warnings.append(str(exc))
+    else:
+        warnings.append("systemctl no está disponible; no se reinició systemd-timesyncd.")
+
+    try:
+        # Touch the timesync status so that timesyncd performs an update soon.
+        _run_command(["timedatectl", "timesync-status"])
+    except RuntimeError as exc:
+        warnings.append(str(exc))
+
+    return SyncTimeResponse(
+        message="Sincronización NTP solicitada.",
+        warnings=warnings,
+        time=_gather_time_status(),
+    )
+
+
+__all__ = ["router"]

--- a/edge/webui/src/api.ts
+++ b/edge/webui/src/api.ts
@@ -6,6 +6,8 @@ import {
   StationConfig,
   StorageSettings,
   StopResponse,
+  SyncTimeResponse,
+  TimeStatus,
 } from "./types";
 
 export interface ApiClientOptions {
@@ -126,6 +128,10 @@ export class ApiClient {
     return this.request<SessionStatusResponse>("/acquisition/session");
   }
 
+  async getTimeStatus(): Promise<TimeStatus> {
+    return this.request<TimeStatus>("/system/time");
+  }
+
   async startAcquisition(payload: StartSessionRequest): Promise<SessionStatusResponse["session"]> {
     return this.request("/acquisition/start", {
       method: "POST",
@@ -135,6 +141,12 @@ export class ApiClient {
 
   async stopAcquisition(): Promise<StopResponse> {
     return this.request<StopResponse>("/acquisition/stop", {
+      method: "POST",
+    });
+  }
+
+  async syncTime(): Promise<SyncTimeResponse> {
+    return this.request<SyncTimeResponse>("/system/time/sync", {
       method: "POST",
     });
   }

--- a/edge/webui/src/pages/SystemTimePanel.tsx
+++ b/edge/webui/src/pages/SystemTimePanel.tsx
@@ -1,0 +1,146 @@
+import { useMemo, useState } from "react";
+import { ApiClient, ApiError } from "../api";
+import { SectionCard } from "../components/SectionCard";
+import { SyncTimeResponse, TimeStatus } from "../types";
+
+interface SystemTimePanelProps {
+  api: ApiClient | null;
+  status: TimeStatus | null;
+  loading: boolean;
+  onRefresh: () => Promise<unknown> | unknown;
+  onSynced: () => Promise<unknown> | unknown;
+  onError: (message: string) => void;
+}
+
+function formatBoolean(value: boolean | null | undefined) {
+  if (value === true) return "Sí";
+  if (value === false) return "No";
+  return "Desconocido";
+}
+
+function formatDate(value: string | null | undefined, timeZone?: string | null) {
+  if (!value) {
+    return "—";
+  }
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    const options: Intl.DateTimeFormatOptions = {
+      dateStyle: "medium",
+      timeStyle: "medium",
+    };
+    if (timeZone) {
+      options.timeZone = timeZone;
+    }
+    const formatter = new Intl.DateTimeFormat(undefined, options);
+    return formatter.format(date);
+  } catch (error) {
+    return value;
+  }
+}
+
+export function SystemTimePanel({ api, status, loading, onRefresh, onSynced, onError }: SystemTimePanelProps) {
+  const [syncing, setSyncing] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
+
+  const disabled = useMemo(() => loading || syncing || !api, [api, loading, syncing]);
+
+  const handleSync = async () => {
+    if (!api || syncing) {
+      return;
+    }
+    setSyncing(true);
+    setSuccessMessage(null);
+    setWarnings([]);
+    try {
+      const response: SyncTimeResponse = await api.syncTime();
+      setSuccessMessage(response.message ?? "Sincronización solicitada.");
+      setWarnings(response.warnings ?? []);
+      await onSynced();
+    } catch (error) {
+      if (error instanceof ApiError) {
+        onError(error.message);
+      } else {
+        onError("No se pudo sincronizar la hora con el servidor NTP.");
+      }
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    setSuccessMessage(null);
+    setWarnings([]);
+    await onRefresh();
+  };
+
+  return (
+    <SectionCard
+      id="system-time"
+      title="Hora del sistema"
+      description="Verifica la sincronización antes de iniciar una nueva sesión de adquisición."
+      actions={
+        <div className="actions">
+          <button type="button" className="secondary" onClick={handleRefresh} disabled={loading || syncing}>
+            Actualizar
+          </button>
+          <button type="button" onClick={handleSync} disabled={disabled}>
+            {syncing ? "Sincronizando…" : "Sincronizar con NTP"}
+          </button>
+        </div>
+      }
+    >
+      {status ? (
+        <div className="time-grid">
+          <div className="time-primary">
+            <p className="time-reading">{formatDate(status.system_time, status.timezone)}</p>
+            {status.timezone && <p className="muted">Zona horaria: {status.timezone}</p>}
+            {successMessage && <p className="success-text">{successMessage}</p>}
+            {warnings.map((warning) => (
+              <p key={warning} className="warning-text">
+                {warning}
+              </p>
+            ))}
+          </div>
+          <dl className="time-meta">
+            <div>
+              <dt>NTP habilitado</dt>
+              <dd>{formatBoolean(status.ntp_enabled)}</dd>
+            </div>
+            <div>
+              <dt>Sincronizado</dt>
+              <dd>{formatBoolean(status.ntp_synchronized)}</dd>
+            </div>
+            <div>
+              <dt>Última sincronización exitosa</dt>
+              <dd>{formatDate(status.last_successful_sync, status.timezone)}</dd>
+            </div>
+            <div>
+              <dt>Último intento</dt>
+              <dd>{formatDate(status.last_attempt_sync, status.timezone)}</dd>
+            </div>
+            <div>
+              <dt>Servidor NTP</dt>
+              <dd>
+                {status.server_name || status.server_address ? (
+                  <span>
+                    {status.server_name}
+                    {status.server_name && status.server_address ? " · " : ""}
+                    {status.server_address}
+                  </span>
+                ) : (
+                  "—"
+                )}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      ) : (
+        <p className="muted">{loading ? "Cargando estado horario…" : "No se pudo obtener el estado horario."}</p>
+      )}
+    </SectionCard>
+  );
+}

--- a/edge/webui/src/styles/index.css
+++ b/edge/webui/src/styles/index.css
@@ -260,6 +260,54 @@ legend {
   min-height: 320px;
 }
 
+.time-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.time-primary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.time-reading {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.time-meta {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.time-meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.time-meta dt {
+  font-weight: 600;
+  color: #38bdf8;
+}
+
+.time-meta dd {
+  margin: 0;
+}
+
+.success-text {
+  color: #bbf7d0;
+}
+
+.warning-text {
+  color: #facc15;
+}
+
 .status-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -310,5 +358,11 @@ legend {
   .token-manager {
     flex-direction: column;
     align-items: stretch;
+  }
+}
+
+@media (max-width: 720px) {
+  .time-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/edge/webui/src/types.ts
+++ b/edge/webui/src/types.ts
@@ -105,6 +105,23 @@ export interface StopResponse {
   session: SessionSummary;
 }
 
+export interface TimeStatus {
+  system_time: string;
+  timezone: string | null;
+  ntp_enabled: boolean | null;
+  ntp_synchronized: boolean | null;
+  last_successful_sync: string | null;
+  last_attempt_sync: string | null;
+  server_name: string | null;
+  server_address: string | null;
+}
+
+export interface SyncTimeResponse {
+  message: string;
+  warnings: string[];
+  time: TimeStatus;
+}
+
 export interface PreviewChannelPayload {
   index: number;
   name: string;


### PR DESCRIPTION
## Summary
- add a FastAPI system router that exposes the current clock/ntp status and allows triggering a sync
- surface the clock status in the web UI with a dedicated panel and hook the sync action through the new API methods
- extend styling/type definitions and ignore TypeScript build artefacts

## Testing
- npm run build *(fails: tsc -b complains that tsconfig.node.json disables emit)*

------
https://chatgpt.com/codex/tasks/task_e_68d4db3e7a5883319041e7b6a2d3caa6