### PR TITLE
Add logs endpoint and UI tab to monitor acquisition issues

### DIFF
--- a/edge/webapi/__init__.py
+++ b/edge/webapi/__init__.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 
 from .acquisition import router as acquisition_router
 from .configuration import router as config_router
+from .logs import router as logs_router
 from .preview import router as preview_router
 from .system import router as system_router
 
@@ -15,6 +16,7 @@ app.include_router(config_router)
 app.include_router(acquisition_router)
 app.include_router(preview_router)
 app.include_router(system_router)
+app.include_router(logs_router)
 
 
 __all__ = ["app"]

--- a/edge/webapi/logs.py
+++ b/edge/webapi/logs.py
@@ -1,0 +1,164 @@
+"""Endpoints to expose recent log entries for troubleshooting."""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from .auth import require_token
+
+LogCategory = Literal["acquisition", "storage"]
+
+router = APIRouter(prefix="/logs", tags=["logs"])
+
+
+LOG_LINE_PATTERN = re.compile(
+    r"^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\s+"
+    r"(?P<level>[A-Z]+)\s+"
+    r"(?P<logger>[^:]+):\s+"
+    r"(?P<message>.*)$"
+)
+
+
+@dataclass
+class ParsedLogLine:
+    timestamp: datetime
+    level: str
+    logger: str
+    message: str
+    category: LogCategory
+
+
+class LogEntry(BaseModel):
+    timestamp: datetime = Field(description="Marca temporal del evento de log")
+    level: str = Field(description="Nivel de severidad (WARNING/ERROR/CRITICAL)")
+    logger: str = Field(description="Nombre del logger que emitió el mensaje")
+    message: str = Field(description="Contenido del mensaje de log")
+    category: LogCategory = Field(description="Categoría inferida del evento")
+
+
+class LogsResponse(BaseModel):
+    acquisition: list[LogEntry] = Field(
+        default_factory=list,
+        description="Eventos relevantes de la adquisición MCC128",
+    )
+    storage: list[LogEntry] = Field(
+        default_factory=list,
+        description="Eventos relevantes del almacenamiento InfluxDB",
+    )
+
+
+def _resolve_log_paths() -> dict[LogCategory, Path]:
+    """Return log file paths based on environment variables."""
+
+    acquisition_path = Path(
+        os.environ.get("EDGE_LOG_ACQUISITION_PATH", "/var/log/edge/acquisition.log")
+    )
+    storage_path = Path(
+        os.environ.get(
+            "EDGE_LOG_STORAGE_PATH",
+            os.environ.get("EDGE_LOG_SENDER_PATH", str(acquisition_path)),
+        )
+    )
+    return {"acquisition": acquisition_path, "storage": storage_path}
+
+
+def _tail_lines(path: Path, max_lines: int) -> list[str]:
+    """Return the last ``max_lines`` lines from ``path`` safely."""
+
+    if not path.exists() or not path.is_file():
+        return []
+
+    chunk_size = 4096
+    buffer = bytearray()
+    newline_count = 0
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            position = handle.tell()
+            while position > 0 and newline_count <= max_lines:
+                read_size = min(chunk_size, position)
+                position -= read_size
+                handle.seek(position)
+                chunk = handle.read(read_size)
+                buffer = chunk + buffer
+                newline_count = buffer.count(b"\n")
+                if position == 0:
+                    break
+    except OSError as exc:  # pragma: no cover - unexpected I/O failure
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"No se pudo leer el log {path}: {exc}",
+        ) from exc
+
+    text = buffer.decode("utf-8", errors="replace")
+    lines = text.splitlines()
+    return lines[-max_lines:]
+
+
+def _categorize(logger_name: str, message: str) -> LogCategory:
+    lowered_logger = logger_name.lower()
+    lowered_message = message.lower()
+    if any(keyword in lowered_logger for keyword in ("sender", "influx", "sink")):
+        return "storage"
+    if "influx" in lowered_message:
+        return "storage"
+    return "acquisition"
+
+
+def _parse_line(line: str) -> ParsedLogLine | None:
+    match = LOG_LINE_PATTERN.match(line.strip())
+    if not match:
+        return None
+    try:
+        timestamp = datetime.strptime(match.group("timestamp"), "%Y-%m-%d %H:%M:%S,%f")
+    except ValueError:
+        return None
+    level = match.group("level")
+    if level not in {"WARNING", "ERROR", "CRITICAL"}:
+        return None
+    logger_name = match.group("logger")
+    message = match.group("message")
+    category = _categorize(logger_name, message)
+    return ParsedLogLine(timestamp, level, logger_name, message, category)
+
+
+def _collect_recent_logs(limit: int) -> LogsResponse:
+    paths = _resolve_log_paths()
+    # Avoid reading the same file twice if both categories share it.
+    unique_paths = {path for path in paths.values()}
+    parsed: list[ParsedLogLine] = []
+    for path in unique_paths:
+        for line in _tail_lines(path, max_lines=limit * 6):
+            parsed_line = _parse_line(line)
+            if parsed_line:
+                parsed.append(parsed_line)
+    parsed.sort(key=lambda item: item.timestamp)
+
+    acquisition_entries = [
+        LogEntry(**parsed_line.__dict__)
+        for parsed_line in parsed
+        if parsed_line.category == "acquisition"
+    ][-limit:]
+
+    storage_entries = [
+        LogEntry(**parsed_line.__dict__)
+        for parsed_line in parsed
+        if parsed_line.category == "storage"
+    ][-limit:]
+
+    return LogsResponse(acquisition=acquisition_entries, storage=storage_entries)
+
+
+@router.get("", response_model=LogsResponse, dependencies=[Depends(require_token)])
+def get_recent_logs(limit: int = Query(50, ge=1, le=500)) -> LogsResponse:
+    """Return the most recent warning/error log entries for troubleshooting."""
+
+    return _collect_recent_logs(limit)

--- a/edge/webui/src/App.tsx
+++ b/edge/webui/src/App.tsx
@@ -6,6 +6,7 @@ import { TokenManager } from "./components/TokenManager";
 import { PreviewDashboard } from "./pages/PreviewDashboard";
 import { SystemTimePanel } from "./pages/SystemTimePanel";
 import { ServiceStatusPanel } from "./pages/ServiceStatusPanel";
+import { LogsPanel } from "./pages/LogsPanel";
 import { StationConfigView } from "./pages/StationConfigView";
 import { StorageSettingsView } from "./pages/StorageSettingsView";
 import { StationConfig, StorageSettings } from "./types";
@@ -244,6 +245,8 @@ export default function App() {
           onSessionChanged={handleSessionRefresh}
           onError={(message) => setErrorMessage(message)}
         />
+
+        <LogsPanel api={api} onError={(message) => setErrorMessage(message)} />
       </main>
     </div>
   );

--- a/edge/webui/src/api.ts
+++ b/edge/webui/src/api.ts
@@ -4,6 +4,7 @@ import {
   SessionStatusResponse,
   StartSessionRequest,
   StationConfig,
+  LogsResponse,
   StorageSettings,
   StopResponse,
   SyncTimeResponse,
@@ -130,6 +131,16 @@ export class ApiClient {
 
   async getTimeStatus(): Promise<TimeStatus> {
     return this.request<TimeStatus>("/system/time");
+  }
+
+  async getLogs(limit = 50): Promise<LogsResponse> {
+    const params = new URLSearchParams();
+    if (limit) {
+      params.set("limit", String(limit));
+    }
+    const query = params.toString();
+    const path = `/logs${query ? `?${query}` : ""}`;
+    return this.request<LogsResponse>(path);
   }
 
   async startAcquisition(payload: StartSessionRequest): Promise<SessionStatusResponse["session"]> {

--- a/edge/webui/src/pages/LogsPanel.tsx
+++ b/edge/webui/src/pages/LogsPanel.tsx
@@ -1,0 +1,136 @@
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ApiClient, ApiError } from "../api";
+import { SectionCard } from "../components/SectionCard";
+import { LogCategory, LogEntry, LogsResponse } from "../types";
+
+const CATEGORY_LABELS: Record<LogCategory, string> = {
+  acquisition: "Adquisición MCC128",
+  storage: "Almacenamiento InfluxDB",
+};
+
+interface LogsPanelProps {
+  api: ApiClient | null;
+  onError: (message: string) => void;
+  limit?: number;
+}
+
+const LOG_REFRESH_MS = 20000;
+
+function formatTimestamp(value: string): string {
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return value;
+  }
+}
+
+export function LogsPanel({ api, onError, limit = 50 }: LogsPanelProps) {
+  const [activeTab, setActiveTab] = useState<LogCategory>("acquisition");
+
+  const logsQuery = useQuery<LogsResponse, unknown>({
+    queryKey: ["logs", limit],
+    queryFn: () => api!.getLogs(limit),
+    enabled: Boolean(api),
+    refetchInterval: LOG_REFRESH_MS,
+  });
+
+  useEffect(() => {
+    if (logsQuery.error instanceof ApiError) {
+      onError(logsQuery.error.message);
+    } else if (logsQuery.error) {
+      onError("No se pudieron cargar los logs recientes.");
+    }
+  }, [logsQuery.error, onError]);
+
+  const logs = useMemo<LogsResponse>(() => {
+    if (!logsQuery.data) {
+      return { acquisition: [], storage: [] };
+    }
+    return logsQuery.data;
+  }, [logsQuery.data]);
+
+  const counts = useMemo<Record<LogCategory, number>>(() => ({
+    acquisition: logs.acquisition.length,
+    storage: logs.storage.length,
+  }), [logs.acquisition.length, logs.storage.length]);
+
+  const activeEntries = logs[activeTab];
+  const isLoading = logsQuery.isLoading || logsQuery.isFetching;
+
+  const handleRefresh = () => {
+    if (!logsQuery.refetch) return;
+    logsQuery.refetch().catch(() => {
+      /* noop */
+    });
+  };
+
+  let panelContent: ReactNode;
+
+  if (!api) {
+    panelContent = <p className="muted">Conecta el backend para revisar los logs.</p>;
+  } else if (isLoading && activeEntries.length === 0) {
+    panelContent = <p>Cargando logs recientes…</p>;
+  } else if (activeEntries.length === 0) {
+    panelContent = <p className="muted">No se registraron advertencias ni errores recientes.</p>;
+  } else {
+    panelContent = (
+      <ul className="log-list">
+        {activeEntries.map((entry: LogEntry) => {
+          const key = `${entry.timestamp}-${entry.logger}-${entry.message}`;
+          const severity = entry.level.toLowerCase();
+          return (
+            <li key={key} className={`log-entry log-${severity}`}>
+              <div className="log-meta">
+                <span className="log-timestamp">{formatTimestamp(entry.timestamp)}</span>
+                <span className="log-level">{entry.level}</span>
+                <span className="log-logger">{entry.logger}</span>
+              </div>
+              <p className="log-message">{entry.message}</p>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+
+  return (
+    <SectionCard
+      id="logs"
+      title="Logs recientes"
+      description="Consulta advertencias y errores emitidos por la adquisición y el almacenamiento."
+      actions={
+        <div className="actions">
+          <button type="button" className="secondary" onClick={handleRefresh} disabled={isLoading || !api}>
+            Actualizar
+          </button>
+        </div>
+      }
+    >
+      <div className="tabs">
+        <div className="tab-list" role="tablist">
+          {(Object.keys(CATEGORY_LABELS) as LogCategory[]).map((category) => {
+            const label = CATEGORY_LABELS[category];
+            const isActive = category === activeTab;
+            return (
+              <button
+                key={category}
+                type="button"
+                className={`tab-button${isActive ? " active" : ""}`}
+                onClick={() => setActiveTab(category)}
+                role="tab"
+                aria-selected={isActive}
+              >
+                {label}
+                {counts[category] > 0 && <span className="badge">{counts[category]}</span>}
+              </button>
+            );
+          })}
+        </div>
+        <div className="tab-panel" role="tabpanel">
+          {panelContent}
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/edge/webui/src/styles/index.css
+++ b/edge/webui/src/styles/index.css
@@ -199,6 +199,113 @@ legend {
   min-width: 140px;
 }
 
+.tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tab-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.tab-button {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: #e2e8f0;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.15s ease;
+}
+
+.tab-button:hover {
+  border-color: #38bdf8;
+  transform: translateY(-1px);
+}
+
+.tab-button.active {
+  background: #38bdf8;
+  color: #0f172a;
+  border-color: transparent;
+}
+
+.tab-button .badge {
+  background: rgba(15, 23, 42, 0.3);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.1rem 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.tab-button.active .badge {
+  background: rgba(15, 23, 42, 0.15);
+}
+
+.tab-panel {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  padding: 1rem;
+  min-height: 160px;
+}
+
+.log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.log-entry {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.log-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.log-level {
+  font-weight: 700;
+}
+
+.log-message {
+  margin: 0;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+}
+
+.log-warning {
+  border-left: 4px solid #facc15;
+}
+
+.log-error {
+  border-left: 4px solid #f87171;
+}
+
+.log-critical {
+  border-left: 4px solid #ef4444;
+}
+
 .checkbox {
   display: flex;
   align-items: center;

--- a/edge/webui/src/types.ts
+++ b/edge/webui/src/types.ts
@@ -141,3 +141,18 @@ export interface PreviewStreamOptions {
   max_duration_s?: number;
   downsample?: number;
 }
+
+export type LogCategory = "acquisition" | "storage";
+
+export interface LogEntry {
+  timestamp: string;
+  level: string;
+  logger: string;
+  message: string;
+  category: LogCategory;
+}
+
+export interface LogsResponse {
+  acquisition: LogEntry[];
+  storage: LogEntry[];
+}

--- a/edge/webui/tests/e2e.spec.ts
+++ b/edge/webui/tests/e2e.spec.ts
@@ -111,6 +111,31 @@ test.describe("Edge WebUI", () => {
       await route.fulfill(jsonResponse(sessionStatus));
     });
 
+    const logsPayload = {
+      acquisition: [
+        {
+          timestamp: new Date().toISOString(),
+          level: "WARNING",
+          logger: "edge.scr.acquisition",
+          message: "Timeout leyendo bloque",
+          category: "acquisition" as const,
+        },
+      ],
+      storage: [
+        {
+          timestamp: new Date().toISOString(),
+          level: "ERROR",
+          logger: "sender",
+          message: "Influx rechazó la escritura",
+          category: "storage" as const,
+        },
+      ],
+    };
+
+    await page.route("**/logs*", async (route) => {
+      await route.fulfill(jsonResponse(logsPayload));
+    });
+
     const previewPayload = {
       station_id: "station-1",
       captured_at_ns: 1_000_000_500,


### PR DESCRIPTION
## Summary
- add a FastAPI `/logs` endpoint that tails recent acquisition and storage warnings/errors
- surface a Logs panel with tabs in the SPA so operators can review MCC128 and InfluxDB issues
- extend tests, typings, and styles to exercise the new functionality

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de1ce9a0b88331a3554edb349d7113