### PR TITLE
Add Influx connectivity health endpoint and UI indicator

### DIFF
--- a/edge/webui/src/App.tsx
+++ b/edge/webui/src/App.tsx
@@ -67,6 +67,13 @@ export default function App() {
     refetchInterval: 15000,
   });
 
+  const influxStatusQuery = useQuery({
+    queryKey: ["influx-status"],
+    queryFn: () => api!.getInfluxStatus(),
+    enabled: Boolean(api),
+    refetchInterval: 30000,
+  });
+
   useEffect(() => {
     if (stationQuery.data) {
       setStationDraft(clone(stationQuery.data));
@@ -103,6 +110,14 @@ export default function App() {
       setErrorMessage("No se pudo obtener la hora del sistema.");
     }
   }, [timeQuery.error]);
+
+  useEffect(() => {
+    if (influxStatusQuery.error instanceof ApiError) {
+      setErrorMessage(influxStatusQuery.error.message);
+    } else if (influxStatusQuery.error) {
+      setErrorMessage("No se pudo verificar la conexión con InfluxDB.");
+    }
+  }, [influxStatusQuery.error]);
 
   const handleStationChange = (next: StationConfig) => {
     setStationDraft(next);
@@ -219,6 +234,13 @@ export default function App() {
           dirty={storageDirty}
           saving={storageSaving}
           loading={storageQuery.isLoading || !api}
+          influxStatus={influxStatusQuery.data ?? null}
+          checkingInflux={influxStatusQuery.isLoading || influxStatusQuery.isFetching}
+          onCheckInflux={() => {
+            influxStatusQuery.refetch().catch(() => {
+              /* handled via react-query */
+            });
+          }}
         />
 
         <SystemTimePanel

--- a/edge/webui/src/api.ts
+++ b/edge/webui/src/api.ts
@@ -9,6 +9,7 @@ import {
   StopResponse,
   SyncTimeResponse,
   TimeStatus,
+  InfluxConnectionStatus,
 } from "./types";
 
 export interface ApiClientOptions {
@@ -141,6 +142,10 @@ export class ApiClient {
     const query = params.toString();
     const path = `/logs${query ? `?${query}` : ""}`;
     return this.request<LogsResponse>(path);
+  }
+
+  async getInfluxStatus(): Promise<InfluxConnectionStatus> {
+    return this.request<InfluxConnectionStatus>("/config/influx/status");
   }
 
   async startAcquisition(payload: StartSessionRequest): Promise<SessionStatusResponse["session"]> {

--- a/edge/webui/src/styles/index.css
+++ b/edge/webui/src/styles/index.css
@@ -199,6 +199,96 @@ legend {
   min-width: 140px;
 }
 
+.influx-status-card {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 14px;
+  padding: 1rem;
+  margin-bottom: 1.25rem;
+  background: rgba(15, 23, 42, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.influx-status-card.status-ok {
+  border-color: rgba(34, 197, 94, 0.4);
+}
+
+.influx-status-card.status-warning {
+  border-color: rgba(234, 179, 8, 0.4);
+}
+
+.influx-status-card.status-error {
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.influx-status-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.status-pill.ok {
+  background: rgba(34, 197, 94, 0.2);
+  color: #4ade80;
+}
+
+.status-pill.warning {
+  background: rgba(234, 179, 8, 0.18);
+  color: #facc15;
+}
+
+.status-pill.error {
+  background: rgba(248, 113, 113, 0.22);
+  color: #f87171;
+}
+
+.status-pill.idle {
+  background: rgba(148, 163, 184, 0.2);
+  color: #cbd5f5;
+}
+
+.status-message {
+  margin: 0;
+}
+
+.influx-status-details {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.influx-status-details div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.influx-status-details dt {
+  font-weight: 600;
+  color: #cbd5f5;
+}
+
+.influx-status-details dd {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #e2e8f0;
+}
+
 .tabs {
   display: flex;
   flex-direction: column;

--- a/edge/webui/src/types.ts
+++ b/edge/webui/src/types.ts
@@ -156,3 +156,18 @@ export interface LogsResponse {
   acquisition: LogEntry[];
   storage: LogEntry[];
 }
+
+export interface InfluxCheckDetail {
+  ok: boolean;
+  message: string;
+  http_status: number | null;
+  latency_ms: number | null;
+}
+
+export interface InfluxConnectionStatus {
+  status: "ok" | "warning" | "error";
+  message: string;
+  checked_at: string;
+  health: InfluxCheckDetail;
+  write: InfluxCheckDetail;
+}


### PR DESCRIPTION
## Summary
- add a backend health check that validates Influx reachability and dry-run writes via /config/influx/status
- surface the connection status in the storage settings panel with a refresh control and styling updates
- extend API client, types, and tests to cover the new endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de2b4ec9688331b83995301f1bf72f